### PR TITLE
tech: Migrate all TODOs to GitHub Issues (#1)

### DIFF
--- a/docs/archive/legacy_todo/TODO_INDEX.md
+++ b/docs/archive/legacy_todo/TODO_INDEX.md
@@ -1,9 +1,20 @@
-# TODO Index
+> ⚠️ **ARCHIVED DOCUMENT**
+>
+> This document is no longer used for task tracking.
+> All active work is tracked exclusively via GitHub Issues.
+>
+> **Migration Date:** 2026-01-14
+> **Migration Issue:** #1
 
-**Status:** Active
+---
+
+# TODO Index (ARCHIVED)
+
+**Status:** ~~Active~~ **ARCHIVED**
 **Version:** v1.3.2
 **Last Updated:** 2026-01-13
 **Audit Method:** Documentation scan (no source code TODO comments)
+**Migration Status:** All items migrated to GitHub Issues #2-#27
 
 ---
 

--- a/src/research/integration/phase_b_hooks.py
+++ b/src/research/integration/phase_b_hooks.py
@@ -44,10 +44,7 @@ def init_vector_backend() -> bool:
         logger.debug("[PhaseB] Vector backend disabled (placeholder)")
         return False
 
-    # TODO: Phase B implementation
-    # - Initialize vector store connection
-    # - Load embedding model
-    # - Verify index exists or create
+    # Migrated to Issue #27 - Phase B vector backend implementation
     logger.warning("[PhaseB] Vector backend not implemented")
     return False
 
@@ -70,9 +67,7 @@ def generate_embedding(text: str) -> Optional[List[float]]:
         logger.debug("[PhaseB] Embedding generation disabled (placeholder)")
         return None
 
-    # TODO: Phase B implementation
-    # - Call embedding model
-    # - Return normalized vector
+    # Migrated to Issue #27 - Phase B vector backend implementation
     logger.warning("[PhaseB] Embedding generation not implemented")
     return None
 
@@ -99,10 +94,7 @@ def vector_search_research_cards(
         logger.debug("[PhaseB] Vector search disabled (placeholder)")
         return []
 
-    # TODO: Phase B implementation
-    # - Query vector store
-    # - Apply filters
-    # - Return ranked results with scores
+    # Migrated to Issue #27 - Phase B vector backend implementation
     logger.warning("[PhaseB] Vector search not implemented")
     return []
 
@@ -129,10 +121,7 @@ def index_research_card(
         logger.debug("[PhaseB] Card indexing disabled (placeholder)")
         return False
 
-    # TODO: Phase B implementation
-    # - Generate embedding for content
-    # - Store in vector database with metadata
-    # - Return success status
+    # Migrated to Issue #27 - Phase B vector backend implementation
     logger.warning("[PhaseB] Card indexing not implemented")
     return False
 
@@ -158,10 +147,7 @@ def compute_semantic_affinity(
         logger.debug("[PhaseB] Semantic affinity disabled (placeholder)")
         return 0.0
 
-    # TODO: Phase B implementation
-    # - Generate embeddings for both inputs
-    # - Compute cosine similarity
-    # - Combine with rule-based affinity
+    # Migrated to Issue #27 - Phase B vector backend implementation
     logger.warning("[PhaseB] Semantic affinity not implemented")
     return 0.0
 
@@ -186,10 +172,7 @@ def cluster_research_cards(
         logger.debug("[PhaseB] Clustering disabled (placeholder)")
         return {}
 
-    # TODO: Phase B implementation
-    # - Generate embeddings for all cards
-    # - Apply clustering algorithm (k-means, HDBSCAN)
-    # - Return cluster assignments
+    # Migrated to Issue #27 - Phase B vector backend implementation
     logger.warning("[PhaseB] Clustering not implemented")
     return {}
 


### PR DESCRIPTION
## Summary

레거시 TODO 기반 작업 추적을 GitHub Issues로 완전 마이그레이션.

## Changes

- 26개 GitHub Issues 생성 (기존 TODO 항목)
- `phase_b_hooks.py` 내 인라인 TODO 6개를 이슈 참조로 대체
- `TODO_INDEX.md`를 `docs/archive/legacy_todo/`로 이동 및 아카이브 헤더 추가

## Migration Report

### Issues Created: 26

| Priority | Count | Issue Numbers |
|----------|-------|---------------|
| P1 | 2 | #2, #3 |
| P2 | 12 | #4-#14 |
| P3 | 12 | #15-#27 |

### Original Location → Issue Mapping

| Original | Issue | Type |
|----------|-------|------|
| TODO-030 | #2 | bug |
| TODO-021 | #3 | feature |
| TODO-001 | #4 | feature |
| TODO-004 | #5 | refactor |
| TODO-005 | #6 | feature |
| TODO-006 | #7 | feature |
| TODO-007 | #8 | feature |
| TODO-022 | #9 | feature |
| TODO-024 | #10 | refactor |
| TODO-014 | #11 | tech-debt |
| TODO-031 | #12 | tech-debt |
| TODO-026 | #13 | docs |
| TODO-027 | #14 | docs |
| TODO-003 | #15 | tech-debt |
| TODO-008 | #16 | tech-debt |
| TODO-009 | #17 | tech-debt |
| TODO-010 | #18 | tech-debt |
| TODO-011 | #19 | refactor |
| TODO-012 | #20 | refactor |
| TODO-013 | #21 | refactor |
| TODO-015 | #22 | tech-debt |
| TODO-025 | #23 | tech-debt |
| TODO-028 | #24 | docs |
| TODO-029 | #25 | docs |
| TODO-032 | #26 | tech-debt |
| Phase B hooks | #27 | feature |

### Documents Archived

| Document | New Location |
|----------|--------------|
| `docs/technical/TODO_INDEX.md` | `docs/archive/legacy_todo/TODO_INDEX.md` |

### Skipped Items (Already Done or Not Planned)

- TODO-016~019: DONE in v1.3.1
- TODO-020: DONE in v1.3.0
- NP-001~005: Explicitly Not Planned

## Test Plan

- [x] No active TODO comments without issue references in Python files
- [x] Archived document has proper header
- [x] All issues created with proper labels

Fixes #1