### PR TITLE
docs: rename GEMINI_MODEL env var to GOOGLE_AI_MODEL (#25)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ LOG_LEVEL=INFO
 # =============================================================================
 GEMINI_ENABLED=false
 GEMINI_API_KEY=your_gemini_api_key_here
-GEMINI_MODEL=deep-research-pro-preview-12-2025
+GOOGLE_AI_MODEL=deep-research-pro-preview-12-2025
 
 # =============================================================================
 # Ollama Configuration (Optional)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ STORY_DEDUP_STRICT=false         # true 시 중복 감지되면 생성 중단
 # 모드: gemini (표준) 또는 deep-research (Deep Research Agent)
 GEMINI_ENABLED=false             # Gemini 활성화 (true로 설정 시 사용 가능)
 GEMINI_API_KEY=your_gemini_key   # Gemini API 키
-GEMINI_MODEL=deep-research-pro-preview-12-2025  # 기본 모델
+GOOGLE_AI_MODEL=deep-research-pro-preview-12-2025  # 기본 모델
 
 # Ollama 설정 (선택 - 로컬 모델)
 OLLAMA_HOST=localhost            # Ollama 호스트

--- a/docs/core/ARCHITECTURE.md
+++ b/docs/core/ARCHITECTURE.md
@@ -472,7 +472,7 @@ flowchart TB
 | Format | Provider | Example |
 |--------|----------|---------|
 | `ollama:{model}` | Ollama | `ollama:llama3`, `ollama:qwen` |
-| `gemini` | Gemini | `gemini` (uses GEMINI_MODEL env) |
+| `gemini` | Gemini | `gemini` (uses GOOGLE_AI_MODEL env) |
 | `gemini:{model}` | Gemini | `gemini:gemini-2.5-flash` |
 | `{claude-model}` | Anthropic | `claude-sonnet-4-5-20250929` |
 | (none) | Default | Story: Claude, Research: Ollama |
@@ -556,7 +556,7 @@ Gemini is **feature-flagged** and only available for research generation.
 ```env
 GEMINI_ENABLED=false          # Must be true to use Gemini
 GEMINI_API_KEY=your_key       # Required when enabled
-GEMINI_MODEL=deep-research-pro-preview-12-2025  # Default model
+GOOGLE_AI_MODEL=deep-research-pro-preview-12-2025  # Default model
 ```
 
 **API Provider:** Google AI Studio (not Vertex AI)

--- a/docs/technical/runbook_24h_test.md
+++ b/docs/technical/runbook_24h_test.md
@@ -590,7 +590,7 @@ optional arguments:
 | `OLLAMA_PORT` | `11434` | Ollama 서버 포트 |
 | `GEMINI_ENABLED` | `false` | Gemini API 활성화 (연구 생성용) |
 | `GEMINI_API_KEY` | - | Gemini API 키 |
-| `GEMINI_MODEL` | `deep-research-pro-preview-12-2025` | 기본 Gemini 모델 |
+| `GOOGLE_AI_MODEL` | `deep-research-pro-preview-12-2025` | 기본 Google AI 모델 |
 
 **Examples:**
 

--- a/docs/verification/GEMINI_DEEP_RESEARCH_VERIFICATION.md
+++ b/docs/verification/GEMINI_DEEP_RESEARCH_VERIFICATION.md
@@ -43,7 +43,7 @@ Integrated Gemini Deep Research Agent as an optional research execution mode:
 | `src/research/executor/__main__.py` | Added load_dotenv() before module imports |
 | `src/research/executor/cli.py` | Handle deep-research mode, skip Ollama checks for Gemini |
 | `src/research/executor/output_writer.py` | Record provider, execution_mode, interaction_id in metadata |
-| `.env.example` | Updated GEMINI_MODEL default to deep-research-pro-preview-12-2025 |
+| `.env.example` | Updated GOOGLE_AI_MODEL default to deep-research-pro-preview-12-2025 |
 | `README.md` | Added deep-research CLI example |
 | `docs/core/ARCHITECTURE.md` | Added Deep Research execution mode documentation |
 | `docs/core/API.md` | Updated research model parameter |
@@ -130,7 +130,7 @@ $ python -m src.research.executor run --help | grep -A3 "model"
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `GEMINI_API_KEY` | (required) | Google AI Studio API key |
-| `GEMINI_MODEL` | `deep-research-pro-preview-12-2025` | Default Gemini model |
+| `GOOGLE_AI_MODEL` | `deep-research-pro-preview-12-2025` | Default Google AI model |
 | `GEMINI_ENABLED` | `false` | Must be true to use Gemini |
 
 **Note:** No additional environment variables invented beyond specification.
@@ -174,7 +174,7 @@ python -m src.research.executor run "Korean horror themes" --model gemini
 - [x] Unified pipeline still auto-injects research into story generation
 - [x] No regression in dedup logic (21/21 tests pass)
 - [x] Documentation updated (README, ARCHITECTURE, API, runbook)
-- [x] Environment variables limited to GEMINI_API_KEY and GEMINI_MODEL
+- [x] Environment variables limited to GEMINI_API_KEY and GOOGLE_AI_MODEL
 
 ---
 

--- a/docs/verification/MODEL_SELECTION_VERIFICATION.md
+++ b/docs/verification/MODEL_SELECTION_VERIFICATION.md
@@ -91,7 +91,7 @@ Location: `src/research/executor/executor.py` (line 204)
 |---------------------|---------|-------------|
 | `GEMINI_ENABLED` | `false` | Must be `true` to use Gemini |
 | `GEMINI_API_KEY` | `""` | Required when enabled |
-| `GEMINI_MODEL` | `gemini-2.5-flash` | Default Gemini model |
+| `GOOGLE_AI_MODEL` | `gemini-2.5-flash` | Default Google AI model |
 
 ### Provider Implementation
 

--- a/src/research/executor/model_provider.py
+++ b/src/research/executor/model_provider.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 # Feature flag for Gemini
 GEMINI_ENABLED = os.getenv("GEMINI_ENABLED", "false").lower() == "true"
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
-GEMINI_MODEL = os.getenv("GEMINI_MODEL", "deep-research-pro-preview-12-2025")
+GOOGLE_AI_MODEL = os.getenv("GOOGLE_AI_MODEL", "deep-research-pro-preview-12-2025")
 
 # Deep Research specific settings
 DEEP_RESEARCH_MODEL = "deep-research-pro-preview-12-2025"
@@ -104,7 +104,7 @@ def parse_research_model_spec(model_spec: Optional[str]) -> ResearchModelInfo:
         if ":" in model_spec:
             model_name = model_spec.split(":", 1)[1]
         else:
-            model_name = GEMINI_MODEL
+            model_name = GOOGLE_AI_MODEL
         return ResearchModelInfo(
             provider="gemini",
             model_name=model_name,


### PR DESCRIPTION
## Summary
- Renamed `GEMINI_MODEL` environment variable to `GOOGLE_AI_MODEL`
- The variable name was misleading since google-genai SDK supports both Gemini and Gemma models
- Updated all references in code and documentation

## Changes
| File | Change |
|------|--------|
| `src/research/executor/model_provider.py` | Renamed variable and env var reference |
| `.env.example` | Updated env var name |
| `README.md` | Updated env var reference |
| `docs/core/ARCHITECTURE.md` | Updated env var references (2 locations) |
| `docs/technical/runbook_24h_test.md` | Updated env var reference |
| `docs/verification/GEMINI_DEEP_RESEARCH_VERIFICATION.md` | Updated env var references (3 locations) |
| `docs/verification/MODEL_SELECTION_VERIFICATION.md` | Updated env var reference |

**Note:** Archive docs (`docs/archive/legacy_todo/TODO_INDEX.md`) intentionally left unchanged as historical record.

## Test plan
- [x] Verify module imports correctly with new env var name
- [x] Run existing test suite (pre-existing async test failures are unrelated)
- [ ] Manual verification with actual Gemini API (optional)

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)