### PR TITLE
fix: prevent release-please workflow loop (#43)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,10 @@
 # - Creates/updates a release PR with changelog
 # - Bumps version in pyproject.toml and src/__init__.py
 # - Creates GitHub release and tag when PR is merged
+#
+# Loop Prevention:
+# - Skips if commit is from release-please (github-actions[bot])
+# - Skips if commit message starts with "chore(release):"
 
 name: Release Please
 
@@ -34,6 +38,15 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    # Skip if triggered by release-please's own commits
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'push' &&
+        !startsWith(github.event.head_commit.message, 'chore(release):') &&
+        github.event.head_commit.author.name != 'github-actions[bot]'
+      )
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
release-please 워크플로우 무한 루프 방지

## Problem
release-please PR이 머지되면 다시 release-please가 트리거되어 루프 발생

## Solution
job-level `if` 조건 추가:
```yaml
if: |
  github.event_name == 'workflow_dispatch' ||
  (
    github.event_name == 'push' &&
    !startsWith(github.event.head_commit.message, 'chore(release):') &&
    github.event.head_commit.author.name != 'github-actions[bot]'
  )
```

## Skip Conditions
- `github-actions[bot]` 커밋 → 스킵
- `chore(release):` 메시지 → 스킵
- `workflow_dispatch` → 항상 실행

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)