### PR TITLE
fix: use token-based loop prevention for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,8 +12,7 @@
 # - Creates GitHub release and tag when PR is merged
 #
 # Loop Prevention:
-# - Skips if commit is from release-please (github-actions[bot])
-# - Skips if commit message starts with "chore(release):"
+# - Token-based: release-please action internally tracks its own commits
 
 name: Release Please
 
@@ -37,31 +36,35 @@ permissions:
 
 jobs:
   release-please:
+    name: Create Release
     runs-on: ubuntu-latest
-    # Skip if triggered by release-please's own commits
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event_name == 'push' &&
-        !startsWith(github.event.head_commit.message, 'chore(release):') &&
-        github.event.head_commit.author.name != 'github-actions[bot]'
-      )
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      version: ${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Run Release Please (Dry Run)
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == 'true' }}
         uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           dry-run: true
 
       - name: Run Release Please
+        id: release
         if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == 'false') }}
         uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Output Release Info
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          echo "✅ Release created!"
+          echo "Tag: ${{ steps.release.outputs.tag_name }}"
+          echo "Version: ${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}"


### PR DESCRIPTION
## Summary
release-please 루프 방지를 token 기반으로 변경

## Changes
- `token: ${{ secrets.GITHUB_TOKEN }}` 파라미터 추가
- job-level `if` 조건 제거 (unreliable)
- outputs 추가: `release_created`, `tag_name`, `version`

## Why Token-based?
- release-please action이 내부적으로 자신의 커밋을 추적
- 커밋 메시지/작성자 체크보다 안정적
- 머지 커밋의 메시지가 달라지는 문제 해결

Refs #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)