### PR TITLE
refactor(api): implement cross-pipeline canonical key matching (#21)

### DIFF
--- a/src/api/schemas/research.py
+++ b/src/api/schemas/research.py
@@ -110,3 +110,56 @@ class ResearchDedupCheckResponse(BaseModel):
     similar_cards: List[SimilarCard] = Field(default=[], description="List of similar cards")
     index_size: int = Field(default=0, description="Number of cards in FAISS index")
     message: Optional[str] = Field(default=None, description="Status message")
+
+
+# =============================================================================
+# Issue #21: Cross-pipeline Canonical Key Matching (Research → Templates)
+# =============================================================================
+
+
+class MatchingTemplateItem(BaseModel):
+    """Summary of a matching template for a research card."""
+
+    template_id: str = Field(..., description="Template ID (e.g., T-SYS-001)")
+    template_name: str = Field(..., description="Human-readable template name")
+    match_score: float = Field(..., description="Match score (0.0-1.0)")
+    canonical_core: dict = Field(default={}, description="Template's canonical core values")
+    match_details: Optional[dict] = Field(default=None, description="Per-dimension match breakdown")
+
+
+class ResearchMatchingTemplatesRequest(BaseModel):
+    """Request to find matching templates for a research card."""
+
+    card_id: str = Field(
+        ...,
+        description="Research card ID to match against templates",
+        json_schema_extra={"examples": ["RC-20260115-143052"]}
+    )
+    max_templates: int = Field(
+        default=5,
+        ge=1,
+        le=15,
+        description="Maximum number of templates to return"
+    )
+    min_score: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description="Minimum match score threshold (0.0-1.0)"
+    )
+
+
+class ResearchMatchingTemplatesResponse(BaseModel):
+    """Response with matching templates for a research card."""
+
+    card_id: str = Field(..., description="Research card ID that was matched")
+    matching_templates: List[MatchingTemplateItem] = Field(
+        default=[],
+        description="List of matching templates sorted by score (highest first)"
+    )
+    total_templates: int = Field(..., description="Total number of templates evaluated")
+    card_affinity: Optional[dict] = Field(
+        default=None,
+        description="The research card's canonical affinity used for matching"
+    )
+    message: Optional[str] = Field(default=None, description="Status message")

--- a/src/infra/research_context/selector.py
+++ b/src/infra/research_context/selector.py
@@ -3,13 +3,17 @@ Research Card Selector
 
 Selects relevant research cards based on canonical affinity matching
 with template skeletons. Filters out HIGH duplicates by default.
+
+Phase 4 (Issue #21): Bi-directional matching support
+- Forward: select_research_for_template() - Template → Research cards
+- Reverse: select_templates_for_research() - Research card → Templates
 """
 
 import logging
 from dataclasses import dataclass, field
 from typing import Dict, Any, List, Optional
 
-from .repository import load_usable_research_cards, get_canonical_affinity
+from .repository import load_usable_research_cards, get_canonical_affinity, get_card_by_id
 from .policy import DedupLevel
 
 logger = logging.getLogger(__name__)
@@ -22,11 +26,18 @@ DIMENSION_WEIGHTS = {
     "mechanism": 1.3,
 }
 
-# Minimum score threshold for selection
+# Minimum score threshold for selection (forward: template → research)
 MIN_MATCH_SCORE = 0.25
+
+# Minimum score threshold for reverse selection (research → template)
+# Higher threshold for stricter filtering (Issue #21)
+MIN_REVERSE_MATCH_SCORE = 0.5
 
 # Maximum cards to return in selection
 MAX_SELECTED_CARDS = 3
+
+# Maximum templates to return in reverse selection
+MAX_SELECTED_TEMPLATES = 5
 
 
 @dataclass
@@ -243,3 +254,229 @@ def select_best_match(
         exclude_level=exclude_level
     )
     return selection.best_card
+
+
+# =============================================================================
+# Issue #21: Reverse Matching (Research → Templates)
+# =============================================================================
+
+
+@dataclass
+class TemplateSelection:
+    """
+    Result of template selection for a research card.
+
+    Symmetric to ResearchSelection for bi-directional matching.
+
+    Attributes:
+        templates: List of selected template skeletons
+        scores: List of match scores corresponding to templates
+        match_details: Per-template match breakdown
+        total_available: Total templates available
+        reason: Human-readable selection reason
+        template_ids: List of selected template IDs (for traceability)
+    """
+    templates: List[Dict[str, Any]] = field(default_factory=list)
+    scores: List[float] = field(default_factory=list)
+    match_details: List[Dict[str, Any]] = field(default_factory=list)
+    total_available: int = 0
+    reason: str = ""
+    template_ids: List[str] = field(default_factory=list)
+
+    @property
+    def has_matches(self) -> bool:
+        """Check if any templates were selected."""
+        return len(self.templates) > 0
+
+    @property
+    def best_template(self) -> Optional[Dict[str, Any]]:
+        """Get the highest-scoring template."""
+        return self.templates[0] if self.templates else None
+
+    @property
+    def best_score(self) -> float:
+        """Get the highest match score."""
+        return self.scores[0] if self.scores else 0.0
+
+    def to_traceability_dict(self) -> Dict[str, Any]:
+        """Get dict for metadata traceability."""
+        return {
+            "matching_templates": self.template_ids,
+            "best_match_score": self.best_score,
+            "total_candidates": self.total_available,
+            "selection_reason": self.reason,
+        }
+
+
+def compute_reverse_affinity_score(
+    card_affinity: Dict[str, List[str]],
+    template_canonical: Dict[str, str]
+) -> tuple[float, Dict[str, Any]]:
+    """
+    Compute affinity match score from research card to template (reverse direction).
+
+    Uses same weighted scoring as forward matching:
+    - For each dimension, check if template's single value appears in card's affinity list
+    - Apply dimension weight to matches
+    - Normalize by total possible weighted score
+
+    This is symmetric to compute_affinity_score() but with reversed argument order
+    for semantic clarity.
+
+    Args:
+        card_affinity: Research card's canonical_affinity (lists)
+        template_canonical: Template's canonical_core (single values)
+
+    Returns:
+        Tuple of (score, match_details)
+    """
+    total_weight = 0.0
+    matched_weight = 0.0
+    details = {}
+
+    for dim, weight in DIMENSION_WEIGHTS.items():
+        template_value = template_canonical.get(dim, "")
+        card_values = set(card_affinity.get(dim, []))
+
+        match = template_value in card_values if template_value else False
+
+        details[dim] = {
+            "template_value": template_value,
+            "card_values": list(card_values),
+            "match": match,
+            "weight": weight,
+        }
+
+        if template_value:
+            total_weight += weight
+            if match:
+                matched_weight += weight
+
+    score = matched_weight / total_weight if total_weight > 0 else 0.0
+    details["_score"] = score
+
+    return score, details
+
+
+def select_templates_for_research(
+    card: Dict[str, Any],
+    templates: Optional[List[Dict[str, Any]]] = None,
+    max_templates: int = MAX_SELECTED_TEMPLATES,
+    min_score: float = MIN_REVERSE_MATCH_SCORE,
+) -> TemplateSelection:
+    """
+    Select template skeletons relevant to a research card (Issue #21).
+
+    Reverse direction of select_research_for_template():
+    Given a research card's canonical_affinity, find templates whose
+    canonical_core values appear in the card's affinity lists.
+
+    This function NEVER raises exceptions - always returns a valid
+    TemplateSelection (possibly with empty templates list).
+
+    Args:
+        card: Research card with output.canonical_affinity
+        templates: Optional list of template skeletons (loads from file if None)
+        max_templates: Maximum templates to return
+        min_score: Minimum score threshold (default 0.5 for stricter filtering)
+
+    Returns:
+        TemplateSelection with matched templates
+    """
+    card_id = card.get("card_id", "unknown")
+
+    # Extract canonical_affinity from card
+    card_affinity = get_canonical_affinity(card)
+
+    logger.info(f"[ResearchContext] Selecting templates for card: {card_id}")
+    logger.debug(f"[ResearchContext] Card affinity: {card_affinity}")
+
+    # Load templates if not provided
+    if templates is None:
+        try:
+            from src.story.template_loader import load_template_skeletons
+            templates = load_template_skeletons()
+        except Exception as e:
+            logger.warning(f"[ResearchContext] Failed to load templates: {e}")
+            return TemplateSelection(reason=f"Template load failed: {e}")
+
+    if not templates:
+        logger.info("[ResearchContext] No templates available")
+        return TemplateSelection(reason="No templates available")
+
+    # Score all templates
+    scored_templates = []
+    for template in templates:
+        template_canonical = template.get("canonical_core", {})
+        score, details = compute_reverse_affinity_score(card_affinity, template_canonical)
+
+        if score >= min_score:
+            scored_templates.append({
+                "template": template,
+                "score": score,
+                "details": details,
+            })
+
+    # Sort by score (highest first)
+    scored_templates.sort(key=lambda x: x["score"], reverse=True)
+
+    # Apply limit
+    selected = scored_templates[:max_templates]
+
+    if not selected:
+        logger.info(f"[ResearchContext] No templates above threshold {min_score}")
+        return TemplateSelection(
+            total_available=len(templates),
+            reason=f"No templates scored above {min_score} threshold"
+        )
+
+    # Build result
+    result_templates = [s["template"] for s in selected]
+    scores = [s["score"] for s in selected]
+    match_details = [s["details"] for s in selected]
+    template_ids = [t.get("template_id", "unknown") for t in result_templates]
+
+    # Log selection
+    for i, s in enumerate(selected):
+        template_id = s["template"].get("template_id", "unknown")
+        template_name = s["template"].get("template_name", "Unknown")
+        logger.info(
+            f"[ResearchContext] Matched #{i+1}: {template_id} ({template_name}) "
+            f"score={s['score']:.2f}"
+        )
+
+    reason = f"Selected {len(result_templates)}/{len(templates)} templates for {card_id}"
+    logger.info(f"[ResearchContext] {reason}")
+
+    return TemplateSelection(
+        templates=result_templates,
+        scores=scores,
+        match_details=match_details,
+        total_available=len(templates),
+        reason=reason,
+        template_ids=template_ids,
+    )
+
+
+def select_best_template_for_research(
+    card: Dict[str, Any],
+    templates: Optional[List[Dict[str, Any]]] = None,
+) -> Optional[Dict[str, Any]]:
+    """
+    Select the single best matching template for a research card.
+
+    Convenience function for getting top template match.
+
+    Args:
+        card: Research card with output.canonical_affinity
+        templates: Optional list of template skeletons (loads from file if None)
+
+    Returns:
+        Best matching template or None
+    """
+    selection = select_templates_for_research(
+        card=card,
+        templates=templates,
+        max_templates=1,
+    )
+    return selection.best_template


### PR DESCRIPTION
## Summary

- **양방향 Canonical Key 매칭 시스템 구현** (Issue #21)
- Research 카드의 `canonical_affinity`와 Template의 `canonical_core` 간 자동 매칭 지원
- 기존 Forward 매칭 (Template → Research)과 대칭적인 Reverse 매칭 (Research → Template) 추가

## Changes

### Core Implementation (`src/infra/research_context/selector.py`)
- `TemplateSelection` dataclass 추가 (ResearchSelection과 대칭)
- `compute_reverse_affinity_score()` 함수 추가 (동일한 가중치 알고리즘)
- `select_templates_for_research()` 함수 추가
- `select_best_template_for_research()` 편의 함수 추가

### API Endpoint (`src/api/routers/research.py`)
- `POST /research/matching-templates` 엔드포인트 추가
- Request: `card_id`, `max_templates`, `min_score`
- Response: `matching_templates[]`, `total_templates`, `card_affinity`

### Configuration
- `MIN_REVERSE_MATCH_SCORE = 0.5` (Forward의 0.25보다 엄격)
- `MAX_SELECTED_TEMPLATES = 5`

### Documentation
- `CANONICAL_KEY_APPLICATION_SCOPE.md` 업데이트
- "Deferred" 섹션에서 "Implemented" 섹션으로 이동

## Test Plan

- [x] `TestReverseAffinityScoring` 테스트 클래스 추가 (5개 테스트)
- [x] `TestTemplateSelection` 테스트 클래스 추가 (5개 테스트)
- [x] Forward/Reverse 매칭 대칭성 검증 테스트
- [x] 전체 테스트 통과 확인 (602 passed)

## API Usage Example

```bash
curl -X POST http://localhost:8000/api/research/matching-templates \
  -H "Content-Type: application/json" \
  -d '{"card_id": "RC-20260115-143052", "min_score": 0.5}'
```

Fixes #21

🤖 Generated with [Claude Code](https://claude.ai/code)