### PR TITLE
ci: exempt develop→main PRs from issue link validation

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -47,6 +47,15 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const baseBranch = context.payload.pull_request.base.ref;
+            const headBranch = context.payload.pull_request.head.ref;
+
+            // develop → main PR은 릴리즈/동기화 목적이므로 Issue 연결 검증 건너뛰기
+            if (baseBranch === 'main' && headBranch === 'develop') {
+              console.log('✅ develop → main PR은 Issue 연결 검증을 건너뜁니다.');
+              return;
+            }
+
             const prBody = context.payload.pull_request.body || '';
 
             // Issue 연결 패턴: Fixes #123, Closes #123, Resolves #123, Refs #123 등


### PR DESCRIPTION
## Summary
- develop → main PR에 대해 Issue 연결 검증 건너뛰기
- 릴리즈/동기화 목적의 PR은 특정 이슈를 링크하기 어려움

## Changes
- `.github/workflows/pr-checks.yml`: base=main, head=develop 조건 추가

## Test plan
- [ ] develop → main PR 생성 시 Issue 링크 검증 통과 확인
- [ ] 다른 브랜치 → main PR은 기존대로 검증 확인
- [ ] 다른 브랜치 → develop PR은 기존대로 검증 확인

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)