### PR TITLE
docs: align documentation with codebase for v1.5.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,10 +45,22 @@ STORY_DEDUP_STRICT=false
 # Semantic embedding dedup (v1.4.0)
 # Requires Ollama with nomic-embed-text model
 ENABLE_STORY_SEMANTIC_DEDUP=true
-STORY_SEMANTIC_THRESHOLD=0.85
+STORY_SEMANTIC_THRESHOLD_HIGH=0.85
+STORY_SEMANTIC_THRESHOLD_MEDIUM=0.70
 STORY_HYBRID_THRESHOLD=0.85
 STORY_HYBRID_CANONICAL_WEIGHT=0.3
 STORY_HYBRID_SEMANTIC_WEIGHT=0.7
+
+# =============================================================================
+# Story Canonical Key Extraction Configuration (Optional)
+# =============================================================================
+# Extract canonical dimensions from generated story text and compare with template
+ENABLE_STORY_CK_EXTRACTION=true
+STORY_CK_MODEL=
+# Enforcement policy: none/warn/retry/strict (default: warn)
+STORY_CK_ENFORCEMENT=warn
+# Minimum alignment score threshold (0.0-1.0, default: 0.6)
+STORY_CK_MIN_ALIGNMENT=0.6
 
 # =============================================================================
 # Research Integration Configuration (Optional)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Claude API (Sonnet 4.5)를 활용한 한국어 호러 소설 자동 생성 시�
 >
 > 모든 문서는 현재 `src/` 패키지 구조와 Canonical Enum v1.0을 기준으로 작성되었습니다.
 >
-> 운영 상태: [docs/OPERATIONAL_STATUS.md](docs/OPERATIONAL_STATUS.md)
+> 운영 상태: [docs/core/OPERATIONAL_STATUS.md](docs/core/OPERATIONAL_STATUS.md)
 
 ---
 
@@ -25,12 +25,6 @@ Claude API (Sonnet 4.5)를 활용한 한국어 호러 소설 자동 생성 시�
 ## 설치 방법
 
 ### 1. 의존성 설치
-
-```bash
-pip install -r requirements.txt
-```
-
-또는 Poetry 사용 시:
 
 ```bash
 poetry install
@@ -57,7 +51,8 @@ RESEARCH_INJECT_EXCLUDE_DUP_LEVEL=HIGH  # 제외할 중복 레벨 (HIGH/MEDIUM)
 ENABLE_STORY_DEDUP=true          # 스토리 시그니처 기반 중복 검사 활성화
 STORY_DEDUP_STRICT=false         # true 시 중복 감지되면 생성 중단
 ENABLE_STORY_SEMANTIC_DEDUP=true # 시맨틱 임베딩 기반 중복 검사 (v1.4.0)
-STORY_SEMANTIC_THRESHOLD=0.85    # 시맨틱 HIGH 신호 기준점
+STORY_SEMANTIC_THRESHOLD_HIGH=0.85   # 시맨틱 HIGH 신호 기준점
+STORY_SEMANTIC_THRESHOLD_MEDIUM=0.70 # 시맨틱 MEDIUM 신호 기준점
 STORY_HYBRID_THRESHOLD=0.85      # 하이브리드 중복 판정 기준점
 
 # Gemini API 설정 (선택 - 연구 생성 전용)

--- a/docs/core/API.md
+++ b/docs/core/API.md
@@ -162,7 +162,7 @@ curl -X POST http://localhost:8000/story/generate \
 ```json
 {
   "status": "ok",
-  "version": "1.3.2"
+  "version": "1.5.0"
 }
 ```
 

--- a/docs/core/ARCHITECTURE.md
+++ b/docs/core/ARCHITECTURE.md
@@ -1055,4 +1055,4 @@ Key architectural decisions are documented in `docs/technical/decision_log.md`:
 
 ---
 
-**Note:** All documentation reflects v1.2.0 with model selection, Gemini Deep Research integration, and complete deduplication pipeline.
+**Note:** All documentation reflects v1.5.0 with model selection, Gemini Deep Research integration, unified backup/restore system, and complete deduplication pipeline.

--- a/docs/core/OPERATIONAL_STATUS.md
+++ b/docs/core/OPERATIONAL_STATUS.md
@@ -70,7 +70,8 @@
 | 환경 변수 | 기본값 | 설명 |
 |-----------|--------|------|
 | `ENABLE_STORY_SEMANTIC_DEDUP` | `true` | 시맨틱 임베딩 기반 중복 검사 |
-| `STORY_SEMANTIC_THRESHOLD` | `0.85` | 시맨틱 HIGH 신호 기준점 |
+| `STORY_SEMANTIC_THRESHOLD_HIGH` | `0.85` | 시맨틱 HIGH 신호 기준점 |
+| `STORY_SEMANTIC_THRESHOLD_MEDIUM` | `0.70` | 시맨틱 MEDIUM 신호 기준점 |
 | `STORY_HYBRID_THRESHOLD` | `0.85` | 하이브리드 중복 판정 기준점 |
 | `STORY_HYBRID_CANONICAL_WEIGHT` | `0.3` | 하이브리드 canonical 가중치 |
 | `STORY_HYBRID_SEMANTIC_WEIGHT` | `0.7` | 하이브리드 semantic 가중치 |
@@ -124,7 +125,7 @@
 
 ## 명시적 범위 외 (향후 작업)
 
-다음 기능은 v1.3.2에 **포함되지 않습니다**:
+다음 기능은 v1.5.0에 **포함되지 않습니다**:
 
 | 기능 | 상태 |
 |------|------|
@@ -140,9 +141,9 @@
 
 | 보고서 | 위치 |
 |--------|------|
-| 통합 파이프라인 검증 | `docs/analysis/UNIFIED_PIPELINE_FINAL_VERIFICATION.md` |
-| 스토리 중복 검사 검증 | `docs/analysis/STORY_DEDUP_FINAL_VERIFICATION.md` |
-| 전체 파이프라인 스모크 테스트 | `docs/analysis/FINAL_PIPELINE_SMOKE_TEST.md` |
+| 통합 파이프라인 검증 | `docs/archive/analysis/UNIFIED_PIPELINE_FINAL_VERIFICATION.md` |
+| 스토리 중복 검사 검증 | `docs/archive/analysis/STORY_DEDUP_FINAL_VERIFICATION.md` |
+| 전체 파이프라인 스모크 테스트 | `docs/archive/analysis/FINAL_PIPELINE_SMOKE_TEST.md` |
 | 모델 선택 검증 | `docs/verification/MODEL_SELECTION_VERIFICATION.md` |
 | Gemini Deep Research 검증 | `docs/verification/GEMINI_DEEP_RESEARCH_VERIFICATION.md` |
 | 전체 파이프라인 테스트 (v1.2.0) | `docs/verification/FULL_PIPELINE_TEST_20260113.md` |
@@ -195,14 +196,14 @@ uvicorn src.api.main:app --host 0.0.0.0 --port 8000
 
 ## 선언
 
-이 문서는 v1.3.2의 운영 계약입니다.
+이 문서는 v1.5.0의 운영 계약입니다.
 
 문서에 명시되지 않은 동작은 보장되지 않습니다.
 
 ---
 
 **검증자:** Claude Opus 4.5
-**태그:** v1.3.2
+**태그:** v1.5.0
 
 ---
 

--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -364,7 +364,8 @@ LOG_LEVEL=INFO
 ENABLE_STORY_DEDUP=true              # Enable signature-based dedup
 STORY_DEDUP_STRICT=false             # Abort on duplicate detection
 ENABLE_STORY_SEMANTIC_DEDUP=true     # Enable semantic embedding dedup
-STORY_SEMANTIC_THRESHOLD=0.85        # Semantic HIGH threshold
+STORY_SEMANTIC_THRESHOLD_HIGH=0.85   # Semantic HIGH threshold
+STORY_SEMANTIC_THRESHOLD_MEDIUM=0.70 # Semantic MEDIUM threshold
 STORY_HYBRID_THRESHOLD=0.85          # Hybrid duplicate threshold
 
 # Vector Backend (v1.4.0)

--- a/docs/technical/STORY_SEMANTIC_DEDUP.md
+++ b/docs/technical/STORY_SEMANTIC_DEDUP.md
@@ -86,7 +86,8 @@ ollama pull nomic-embed-text
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ENABLE_STORY_SEMANTIC_DEDUP` | `true` | Enable semantic embedding dedup |
-| `STORY_SEMANTIC_THRESHOLD` | `0.85` | Semantic HIGH signal threshold |
+| `STORY_SEMANTIC_THRESHOLD_HIGH` | `0.85` | Semantic HIGH signal threshold |
+| `STORY_SEMANTIC_THRESHOLD_MEDIUM` | `0.70` | Semantic MEDIUM signal threshold |
 | `STORY_HYBRID_THRESHOLD` | `0.85` | Hybrid duplicate detection threshold |
 | `STORY_HYBRID_CANONICAL_WEIGHT` | `0.3` | Canonical component weight |
 | `STORY_HYBRID_SEMANTIC_WEIGHT` | `0.7` | Semantic component weight |
@@ -225,9 +226,9 @@ from src.infra.data_paths import (
 
 **Symptom:** Unique stories flagged as duplicates.
 
-**Solution:** Lower the thresholds:
+**Solution:** Raise the thresholds:
 ```bash
-STORY_SEMANTIC_THRESHOLD=0.90
+STORY_SEMANTIC_THRESHOLD_HIGH=0.90
 STORY_HYBRID_THRESHOLD=0.90
 ```
 

--- a/docs/technical/openapi.yaml
+++ b/docs/technical/openapi.yaml
@@ -32,7 +32,7 @@ info:
 
     ## Note
     This API is designed for **local use only**. All operations connect to local Ollama instance.
-  version: 1.1.0
+  version: 1.5.0
   contact:
     name: VinylStage
     email: mcpe9869@gmail.com
@@ -298,7 +298,7 @@ components:
         version:
           type: string
           description: API version
-          example: "0.1.0"
+          example: "1.5.0"
 
     ResourceStatusResponse:
       type: object


### PR DESCRIPTION
Fix multiple inconsistencies between documentation and actual code:

- Update version references from 1.3.2/1.2.0/1.1.0 to 1.5.0 across docs
- Fix env var names: STORY_SEMANTIC_THRESHOLD → STORY_SEMANTIC_THRESHOLD_HIGH
- Add missing STORY_CK_* environment variables to .env.example
- Remove non-existent requirements.txt reference from README.md
- Fix OPERATIONAL_STATUS.md link path in README.md
- Correct docs/analysis/* paths to docs/archive/analysis/*
- Add STORY_SEMANTIC_THRESHOLD_MEDIUM documentation

Files modified:
- .env.example: Add CK extraction config section
- README.md: Fix install instructions, env vars, link path
- docs/core/API.md: Update health endpoint version example
- docs/core/ARCHITECTURE.md: Update version note
- docs/core/OPERATIONAL_STATUS.md: Update version refs, env vars, paths
- docs/core/README.md: Fix env var name
- docs/technical/STORY_SEMANTIC_DEDUP.md: Fix env var names
- docs/technical/openapi.yaml: Update API version and examples

Issue #92 