### PR TITLE
ci: add develop→main PR title validation for release-please (#100)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -38,6 +38,38 @@ jobs:
             ✅ fix: 리서치 API 오류 수정
             ❌ feat: Add new template (대문자 시작)
 
+      - name: Additional validation for develop → main PRs
+        if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'develop'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prTitle = context.payload.pull_request.title;
+
+            // Conventional Commits 형식 검증
+            const conventionalCommitPattern = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|tech)(\(.+\))?:\s.+/;
+
+            if (!conventionalCommitPattern.test(prTitle)) {
+              core.setFailed(
+                '❌ develop → main PR 제목이 Conventional Commits 형식을 따르지 않습니다.\n\n' +
+                '⚠️  CRITICAL: release-please는 이 형식에 의존하여 자동 릴리즈를 생성합니다.\n' +
+                '형식을 따르지 않으면 릴리즈가 생성되지 않습니다!\n\n' +
+                '현재 제목: ' + prTitle + '\n\n' +
+                '올바른 형식:\n' +
+                '  <type>: <description> (#<pr-number>)\n\n' +
+                '예시:\n' +
+                '  ✅ feat: implement scheduler API integration (#98)\n' +
+                '  ✅ fix: resolve authentication timeout issue (#102)\n' +
+                '  ✅ docs: update API documentation for v1.6.0 (#105)\n\n' +
+                '잘못된 예시:\n' +
+                '  ❌ Develop (#98)\n' +
+                '  ❌ Merge develop into main\n' +
+                '  ❌ Release v1.6.0\n\n' +
+                '자세한 내용은 CLAUDE.md Section 4.4를 참고하세요.'
+              );
+            } else {
+              console.log('✅ develop → main PR 제목이 올바른 형식입니다: ' + prTitle);
+            }
+
   # PR 본문에 Issue 번호가 포함되어 있는지 검증
   validate-issue-link:
     name: Validate Issue Link

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,39 @@ feat: add router abstraction (#123)
 
 - PRs targeting `main` are **FORBIDDEN** unless explicitly instructed by the user for release-related operations.
 
+### 4.4 Release PR Title Format
+
+When creating a PR from `develop` to `main` (release PR):
+
+- PR title MUST follow [Conventional Commits](https://www.conventionalcommits.org/) format.
+- This is CRITICAL for `release-please` to correctly parse commits and generate releases.
+
+**Format:**
+
+```
+<type>: <description> (#<pr-number>)
+```
+
+**Valid examples:**
+
+```
+feat: implement scheduler API integration (#98)
+fix: resolve authentication timeout issue (#102)
+docs: update API documentation for v1.6.0 (#105)
+```
+
+**Invalid examples:**
+
+```
+❌ Develop (#98)
+❌ Merge develop into main
+❌ Release v1.6.0
+```
+
+**Allowed types:** `feat` | `fix` | `docs` | `refactor` | `tech` | `chore` | `ci` | `test` | `perf`
+
+> **Failure to follow this format will cause `release-please` to skip automatic version bumping and release creation.**
+
 ---
 
 ## 5. Validation Awareness


### PR DESCRIPTION
## 📋 요약

PR #101에서 구현한 develop → main PR 제목 검증 기능을 릴리즈합니다.

---

## 🎯 변경 사항

### 1. CLAUDE.md Section 4.4 추가
- develop → main PR 제목에 Conventional Commits 형식 필수화
- release-please 의존성 명시
- 올바른/잘못된 예시 제공

### 2. GitHub Actions 검증 강화
- develop → main PR 전용 검증 단계 추가
- Conventional Commits 형식 위반 시 상세한 에러 메시지
- 머지 차단으로 release-please 오작동 방지

---

## ✅ 검증

이 PR 자체가 첫 번째 테스트입니다:
- [x] PR 제목이 Conventional Commits 형식을 따름
- [ ] PR Validation 워크플로우 통과 확인
- [ ] develop → main PR 전용 검증 단계 작동 확인

---

## 🔗 관련 Issue

Refs #100

---

🤖 Generated with Claude Code