### PR TITLE
docs: add release-please version placeholders and improve doc links (#92)

### DIFF
--- a/docs/DOCUMENT_MAP.md
+++ b/docs/DOCUMENT_MAP.md
@@ -1,6 +1,7 @@
 # Documentation Map
 
 **Version:** 1.1
+**Application Version:** 1.6.0 <!-- x-release-please-version -->
 **Last Updated:** 2026-01-18
 
 ---

--- a/docs/core/RELEASE_GUIDE.md
+++ b/docs/core/RELEASE_GUIDE.md
@@ -1,5 +1,7 @@
 # develop → main 릴리즈 PR 가이드
 
+> **Application Version:** 1.6.0 <!-- x-release-please-version -->
+
 ## 0. main → develop 동기화 (선택사항)
 
 ### 필요한가?

--- a/docs/job-scheduler/API_CONTRACT.md
+++ b/docs/job-scheduler/API_CONTRACT.md
@@ -2,7 +2,7 @@
 
 > **Status:** IMPLEMENTED (Phase 3 API Integration Complete)
 > **Document Version:** 2.0.0
-> **Application Version:** 1.5.0 (managed by release-please)
+> **Application Version:** 1.6.0 <!-- x-release-please-version -->
 > **Last Updated:** 2026-01-18
 > **Implementation Branch:** feat/88-scheduler-api-integration
 
@@ -331,3 +331,10 @@ Rules:
 - This contract applies to **new scheduler-based execution only**
 
 ---
+
+## Related Documents
+
+- [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) - 도메인 모델 정의
+- [API_IMPACT.md](./API_IMPACT.md) - API 영향 분석
+- [DESIGN_GUARDS.md](./DESIGN_GUARDS.md) - 설계 가드레일 및 결정사항
+- [JOB_SCHEDULER_DESIGN.md](../technical/JOB_SCHEDULER_DESIGN.md) - 시스템 설계 개요

--- a/docs/job-scheduler/API_IMPACT.md
+++ b/docs/job-scheduler/API_IMPACT.md
@@ -2,7 +2,7 @@
 
 > **Status:** FINAL (Phase 5 Complete)
 > **Document Version:** 1.0.0
-> **Application Version:** 1.5.0 (managed by release-please)
+> **Application Version:** 1.6.0 <!-- x-release-please-version -->
 > **Last Updated:** 2026-01-18
 
 ---
@@ -530,4 +530,13 @@ This guarantees:
 | **Legacy System** | Current immediate-execution job system |
 | **Coexistence** | Period where both systems operate in parallel |
 | **Next-Slot Reservation** | Direct API reserving next execution slot without preempting current job |
+
+---
+
+## Related Documents
+
+- [API_CONTRACT.md](./API_CONTRACT.md) - API 계약 및 구현 상태
+- [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) - 도메인 모델 정의
+- [DESIGN_GUARDS.md](./DESIGN_GUARDS.md) - 설계 가드레일
+- [JOB_SCHEDULER_DESIGN.md](../technical/JOB_SCHEDULER_DESIGN.md) - 시스템 설계 개요
 

--- a/docs/job-scheduler/CONCURRENCY_OPTIONS.md
+++ b/docs/job-scheduler/CONCURRENCY_OPTIONS.md
@@ -2,7 +2,7 @@
 
 > **Status:** RESOLVED → DEC-011
 > **Document Version:** 1.0.0
-> **Application Version:** 1.5.0 (managed by release-please)
+> **Application Version:** 1.6.0 <!-- x-release-please-version -->
 > **Last Updated:** 2026-01-18
 >
 > **Decision**: Option A selected — Global single concurrency.
@@ -126,4 +126,13 @@ Phase 5+: When remote API parallelization needed:
 - [ ] Defer Option B/C to future phase
 - [ ] Update DESIGN_GUARDS.md to promote OQ-001 → DEC-011
 - [ ] No persistence schema changes needed for Phase 4
+
+---
+
+## Related Documents
+
+- [DESIGN_GUARDS.md](./DESIGN_GUARDS.md) - 설계 가드레일 (DEC-011 참조)
+- [EXECUTION_FLOW.md](./EXECUTION_FLOW.md) - 실행 흐름 다이어그램
+- [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) - 도메인 모델 정의
+- [JOB_SCHEDULER_DESIGN.md](../technical/JOB_SCHEDULER_DESIGN.md) - 시스템 설계 개요
 

--- a/docs/job-scheduler/DESIGN_GUARDS.md
+++ b/docs/job-scheduler/DESIGN_GUARDS.md
@@ -2,7 +2,7 @@
 
 > **Status:** FINAL (Phase 5 Complete)
 > **Document Version:** 1.0.0
-> **Application Version:** 1.5.0 (managed by release-please)
+> **Application Version:** 1.6.0 <!-- x-release-please-version -->
 > **Last Updated:** 2026-01-18
 
 ---
@@ -486,4 +486,14 @@ Before implementation of any component:
 | 0.1.0 | 2026-01-18 | - | Initial draft |
 | 0.2.0 | 2026-01-18 | - | Aligned with API_CONTRACT.md: unified status model, promoted 5 OQs to decisions, updated DEC-004 to next-slot reservation |
 | 0.3.0 | 2026-01-18 | - | Locked DEC-011 (concurrency) and DEC-012 (JobGroup failure); all open questions resolved |
+
+---
+
+## Related Documents
+
+- [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) - 도메인 모델 정의
+- [PERSISTENCE_SCHEMA.md](./PERSISTENCE_SCHEMA.md) - 영속성 스키마
+- [API_CONTRACT.md](./API_CONTRACT.md) - API 계약
+- [TEST_STRATEGY.md](./TEST_STRATEGY.md) - 테스트 전략
+- [JOB_SCHEDULER_DESIGN.md](../technical/JOB_SCHEDULER_DESIGN.md) - 시스템 설계 개요
 

--- a/docs/job-scheduler/DOMAIN_MODEL.md
+++ b/docs/job-scheduler/DOMAIN_MODEL.md
@@ -2,7 +2,7 @@
 
 > **Status:** FINAL (Phase 5 Complete)
 > **Document Version:** 1.0.0
-> **Application Version:** 1.5.0 (managed by release-please)
+> **Application Version:** 1.6.0 <!-- x-release-please-version -->
 > **Last Updated:** 2026-01-18
 
 ---
@@ -334,3 +334,13 @@ Terminal states:
 | **Worker** | Component that performs actual execution |
 | **Artifact** | File produced by execution (e.g., story JSON) |
 | **Priority** | Relative importance affecting execution order |
+
+---
+
+## Related Documents
+
+- [ENTITY_RELATIONSHIPS.md](./ENTITY_RELATIONSHIPS.md) - 엔티티 관계 정의
+- [PERSISTENCE_SCHEMA.md](./PERSISTENCE_SCHEMA.md) - 영속성 스키마
+- [API_CONTRACT.md](./API_CONTRACT.md) - API 계약
+- [DESIGN_GUARDS.md](./DESIGN_GUARDS.md) - 설계 가드레일
+- [JOB_SCHEDULER_DESIGN.md](../technical/JOB_SCHEDULER_DESIGN.md) - 시스템 설계 개요

--- a/docs/job-scheduler/E2E_TEST_PLAN.md
+++ b/docs/job-scheduler/E2E_TEST_PLAN.md
@@ -1,7 +1,7 @@
 # Job Scheduler End-to-End Test Plan
 
 **Document Version:** 1.1.0
-**Application Version:** 1.5.0 (managed by release-please - DO NOT CHANGE)
+**Application Version:** 1.6.0 <!-- x-release-please-version -->
 **Phase:** 6-B Real Pipeline Validation
 **Last Updated:** 2026-01-18
 
@@ -266,3 +266,13 @@ python -m pytest tests/scheduler/test_pipeline_e2e.py -v --run-pipeline
 | DEC-007 | DESIGN_GUARDS.md | Retry flow tests |
 | DEC-012 | DESIGN_GUARDS.md | JobGroup tests |
 | INV-006 | DESIGN_GUARDS.md | Group completion atomicity |
+
+---
+
+## Related Documents
+
+- [E2E_TEST_REPORT.md](./E2E_TEST_REPORT.md) - E2E 테스트 결과
+- [TEST_STRATEGY.md](./TEST_STRATEGY.md) - 테스트 전략
+- [DESIGN_GUARDS.md](./DESIGN_GUARDS.md) - 설계 가드레일
+- [RECOVERY_SCENARIOS.md](./RECOVERY_SCENARIOS.md) - 복구 시나리오
+- [JOB_SCHEDULER_DESIGN.md](../technical/JOB_SCHEDULER_DESIGN.md) - 시스템 설계 개요

--- a/docs/job-scheduler/E2E_TEST_REPORT.md
+++ b/docs/job-scheduler/E2E_TEST_REPORT.md
@@ -1,7 +1,7 @@
 # Job Scheduler E2E Test Report
 
 **Document Version:** 1.1.0
-**Application Version:** 1.5.0 (managed by release-please)
+**Application Version:** 1.6.0 <!-- x-release-please-version -->
 **Phase:** 6-B Real Pipeline Validation
 **Test Date:** 2026-01-18
 **Status:** PASS
@@ -301,3 +301,13 @@ tests/scheduler/test_e2e.py::TestE2EWebhook::test_e2e_webhook_04_at_least_once_s
 ...
 ======================== 110 passed, 8 skipped in 1.55s ========================
 ```
+
+---
+
+## Related Documents
+
+- [E2E_TEST_PLAN.md](./E2E_TEST_PLAN.md) - E2E 테스트 계획
+- [TEST_STRATEGY.md](./TEST_STRATEGY.md) - 테스트 전략
+- [DESIGN_GUARDS.md](./DESIGN_GUARDS.md) - 설계 가드레일
+- [RECOVERY_SCENARIOS.md](./RECOVERY_SCENARIOS.md) - 복구 시나리오
+- [JOB_SCHEDULER_DESIGN.md](../technical/JOB_SCHEDULER_DESIGN.md) - 시스템 설계 개요

--- a/docs/job-scheduler/ENTITY_RELATIONSHIPS.md
+++ b/docs/job-scheduler/ENTITY_RELATIONSHIPS.md
@@ -2,7 +2,7 @@
 
 > **Status:** FINAL (Phase 5 Complete)
 > **Document Version:** 1.0.0
-> **Application Version:** 1.5.0 (managed by release-please)
+> **Application Version:** 1.6.0 <!-- x-release-please-version -->
 > **Last Updated:** 2026-01-18
 
 ---
@@ -435,4 +435,13 @@ Legend:
 | **Cascade Delete** | Deleting parent automatically deletes children |
 | **Loose Ownership** | Logical grouping without lifecycle dependency |
 | **Derived Status** | Status computed from related entity states |
+
+---
+
+## Related Documents
+
+- [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) - 도메인 모델 정의
+- [PERSISTENCE_SCHEMA.md](./PERSISTENCE_SCHEMA.md) - 영속성 스키마
+- [DESIGN_GUARDS.md](./DESIGN_GUARDS.md) - 설계 가드레일
+- [JOB_SCHEDULER_DESIGN.md](../technical/JOB_SCHEDULER_DESIGN.md) - 시스템 설계 개요
 

--- a/docs/job-scheduler/EXECUTION_FLOW.md
+++ b/docs/job-scheduler/EXECUTION_FLOW.md
@@ -2,7 +2,7 @@
 
 > **Status:** FINAL (Phase 5 Complete)
 > **Document Version:** 1.0.0
-> **Application Version:** 1.5.0 (managed by release-please)
+> **Application Version:** 1.6.0 <!-- x-release-please-version -->
 > **Last Updated:** 2026-01-18
 
 ---
@@ -397,4 +397,14 @@ on_failure: skip     # → Skip remaining without CANCELLED status
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
 | 0.1.0 | 2026-01-18 | - | Initial execution flow diagrams |
+
+---
+
+## Related Documents
+
+- [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) - 도메인 모델 정의
+- [DESIGN_GUARDS.md](./DESIGN_GUARDS.md) - 설계 가드레일
+- [RECOVERY_SCENARIOS.md](./RECOVERY_SCENARIOS.md) - 복구 시나리오
+- [IMPLEMENTATION_PLAN.md](./IMPLEMENTATION_PLAN.md) - 구현 계획
+- [JOB_SCHEDULER_DESIGN.md](../technical/JOB_SCHEDULER_DESIGN.md) - 시스템 설계 개요
 

--- a/docs/job-scheduler/IMPLEMENTATION_PLAN.md
+++ b/docs/job-scheduler/IMPLEMENTATION_PLAN.md
@@ -2,7 +2,7 @@
 
 > **Status:** FINAL (Phase 5 Complete)
 > **Document Version:** 1.0.0
-> **Application Version:** 1.5.0 (managed by release-please)
+> **Application Version:** 1.6.0 <!-- x-release-please-version -->
 > **Last Updated:** 2026-01-18
 
 ---
@@ -714,4 +714,15 @@ The following questions have been resolved and implemented.
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
 | 0.1.0 | 2026-01-18 | - | Initial implementation plan |
+
+---
+
+## Related Documents
+
+- [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) - 도메인 모델 정의
+- [DESIGN_GUARDS.md](./DESIGN_GUARDS.md) - 설계 가드레일
+- [EXECUTION_FLOW.md](./EXECUTION_FLOW.md) - 실행 흐름 다이어그램
+- [PERSISTENCE_SCHEMA.md](./PERSISTENCE_SCHEMA.md) - 영속성 스키마
+- [API_CONTRACT.md](./API_CONTRACT.md) - API 계약
+- [JOB_SCHEDULER_DESIGN.md](../technical/JOB_SCHEDULER_DESIGN.md) - 시스템 설계 개요
 

--- a/docs/job-scheduler/JOBGROUP_BEHAVIOR_OPTIONS.md
+++ b/docs/job-scheduler/JOBGROUP_BEHAVIOR_OPTIONS.md
@@ -2,7 +2,7 @@
 
 > **Status:** RESOLVED → DEC-012
 > **Document Version:** 1.0.0
-> **Application Version:** 1.5.0 (managed by release-please)
+> **Application Version:** 1.6.0 <!-- x-release-please-version -->
 > **Last Updated:** 2026-01-18
 >
 > **Decision**: Option A selected — Stop-on-failure.
@@ -161,4 +161,13 @@ This ensures retry semantics are respected before group-level decisions.
 - [ ] Defer Option C to future phase
 - [ ] Update DESIGN_GUARDS.md to promote OQ-002 → DEC-012
 - [ ] No persistence schema changes needed for Phase 4
+
+---
+
+## Related Documents
+
+- [DESIGN_GUARDS.md](./DESIGN_GUARDS.md) - 설계 가드레일 (DEC-012 참조)
+- [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) - 도메인 모델 정의
+- [EXECUTION_FLOW.md](./EXECUTION_FLOW.md) - 실행 흐름 다이어그램
+- [JOB_SCHEDULER_DESIGN.md](../technical/JOB_SCHEDULER_DESIGN.md) - 시스템 설계 개요
 

--- a/docs/job-scheduler/PERSISTENCE_SCHEMA.md
+++ b/docs/job-scheduler/PERSISTENCE_SCHEMA.md
@@ -2,7 +2,7 @@
 
 > **Status:** FINAL (Phase 5 Complete)
 > **Document Version:** 1.0.0
-> **Application Version:** 1.5.0 (managed by release-please)
+> **Application Version:** 1.6.0 <!-- x-release-please-version -->
 > **Last Updated:** 2026-01-18
 
 ---
@@ -675,4 +675,14 @@ Before any implementation, verify:
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
 | 0.1.0 | 2026-01-18 | - | Initial persistence schema design |
+
+---
+
+## Related Documents
+
+- [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) - 도메인 모델 정의
+- [ENTITY_RELATIONSHIPS.md](./ENTITY_RELATIONSHIPS.md) - 엔티티 관계 정의
+- [DESIGN_GUARDS.md](./DESIGN_GUARDS.md) - 설계 가드레일
+- [RECOVERY_SCENARIOS.md](./RECOVERY_SCENARIOS.md) - 복구 시나리오
+- [JOB_SCHEDULER_DESIGN.md](../technical/JOB_SCHEDULER_DESIGN.md) - 시스템 설계 개요
 

--- a/docs/job-scheduler/RECOVERY_SCENARIOS.md
+++ b/docs/job-scheduler/RECOVERY_SCENARIOS.md
@@ -2,7 +2,7 @@
 
 > **Status:** FINAL (Phase 5 Complete)
 > **Document Version:** 1.0.0
-> **Application Version:** 1.5.0 (managed by release-please)
+> **Application Version:** 1.6.0 <!-- x-release-please-version -->
 > **Last Updated:** 2026-01-18
 
 ---
@@ -422,4 +422,14 @@ test_crash_during_running_job:
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
 | 0.1.0 | 2026-01-18 | - | Initial recovery scenarios |
+
+---
+
+## Related Documents
+
+- [PERSISTENCE_SCHEMA.md](./PERSISTENCE_SCHEMA.md) - 영속성 스키마
+- [DESIGN_GUARDS.md](./DESIGN_GUARDS.md) - 설계 가드레일
+- [TEST_STRATEGY.md](./TEST_STRATEGY.md) - 테스트 전략
+- [E2E_TEST_PLAN.md](./E2E_TEST_PLAN.md) - E2E 테스트 계획
+- [JOB_SCHEDULER_DESIGN.md](../technical/JOB_SCHEDULER_DESIGN.md) - 시스템 설계 개요
 

--- a/docs/job-scheduler/TEST_STRATEGY.md
+++ b/docs/job-scheduler/TEST_STRATEGY.md
@@ -2,7 +2,7 @@
 
 > **Status:** FINAL (Phase 6-A Validated)
 > **Document Version:** 1.0.0
-> **Application Version:** 1.5.0 (managed by release-please)
+> **Application Version:** 1.6.0 <!-- x-release-please-version -->
 > **Last Updated:** 2026-01-18
 
 ---
@@ -609,4 +609,14 @@ For tests requiring concurrent access (PERS-003-A):
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
 | 0.1.0 | 2026-01-18 | - | Initial test strategy |
+
+---
+
+## Related Documents
+
+- [DESIGN_GUARDS.md](./DESIGN_GUARDS.md) - 설계 가드레일
+- [E2E_TEST_PLAN.md](./E2E_TEST_PLAN.md) - E2E 테스트 계획
+- [E2E_TEST_REPORT.md](./E2E_TEST_REPORT.md) - E2E 테스트 결과
+- [RECOVERY_SCENARIOS.md](./RECOVERY_SCENARIOS.md) - 복구 시나리오
+- [JOB_SCHEDULER_DESIGN.md](../technical/JOB_SCHEDULER_DESIGN.md) - 시스템 설계 개요
 

--- a/docs/technical/JOB_SCHEDULER_DESIGN.md
+++ b/docs/technical/JOB_SCHEDULER_DESIGN.md
@@ -1,6 +1,7 @@
 # Job Scheduler System Design
 
 > **Status:** IMPLEMENTED (Phase 3 Complete)
+> **Application Version:** 1.6.0 <!-- x-release-please-version -->
 > **Date:** 2026-01-18
 > **Author:** Claude Code (with VinylStage)
 > **Implementation:** `feat/88-scheduler-api-integration`

--- a/docs/technical/job-scheduler-AS_IS_TO_BE_API_DESIGN-v1.md
+++ b/docs/technical/job-scheduler-AS_IS_TO_BE_API_DESIGN-v1.md
@@ -2,7 +2,7 @@
 
 > **Status:** IMPLEMENTED (Phase 3 Complete)
 > **Document Version:** 1.1.0
-> **Application Version:** 1.5.0
+> **Application Version:** 1.6.0 <!-- x-release-please-version -->
 > **Last Updated:** 2026-01-18
 > **Implementation Commit:** feat/88-scheduler-api-integration
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -67,6 +67,96 @@
           "type": "generic",
           "path": "docs/audit/IMPLEMENTATION_AUDIT.md",
           "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "docs/DOCUMENT_MAP.md",
+          "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "docs/core/RELEASE_GUIDE.md",
+          "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "docs/technical/JOB_SCHEDULER_DESIGN.md",
+          "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "docs/technical/job-scheduler-AS_IS_TO_BE_API_DESIGN-v1.md",
+          "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "docs/job-scheduler/API_CONTRACT.md",
+          "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "docs/job-scheduler/API_IMPACT.md",
+          "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "docs/job-scheduler/CONCURRENCY_OPTIONS.md",
+          "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "docs/job-scheduler/DESIGN_GUARDS.md",
+          "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "docs/job-scheduler/DOMAIN_MODEL.md",
+          "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "docs/job-scheduler/E2E_TEST_PLAN.md",
+          "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "docs/job-scheduler/E2E_TEST_REPORT.md",
+          "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "docs/job-scheduler/ENTITY_RELATIONSHIPS.md",
+          "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "docs/job-scheduler/EXECUTION_FLOW.md",
+          "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "docs/job-scheduler/IMPLEMENTATION_PLAN.md",
+          "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "docs/job-scheduler/JOBGROUP_BEHAVIOR_OPTIONS.md",
+          "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "docs/job-scheduler/PERSISTENCE_SCHEMA.md",
+          "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "docs/job-scheduler/RECOVERY_SCENARIOS.md",
+          "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "docs/job-scheduler/TEST_STRATEGY.md",
+          "glob": false
         }
       ]
     }


### PR DESCRIPTION
## 📋 관련 Issue

Refs #92

---

## 📝 변경 사항

### 주요 변경 내용

- **release-please-config.json**: 18개 신규 파일 추가
    
    - `docs/job-scheduler/*.md` (14개)
    - `docs/DOCUMENT_MAP.md`
    - `docs/technical/JOB_SCHEDULER_DESIGN.md`
    - `docs/technical/job-scheduler-AS_IS_TO_BE_API_DESIGN-v1.md`
    - `docs/core/RELEASE_GUIDE.md`
- **Version Placeholder 적용**: 18개 파일에 `<!-- x-release-please-version -->` 추가
    
    - 기존 `1.5.0 (managed by release-please)` → `1.6.0 <!-- x-release-please-version -->`
- **Related Documents 섹션 추가**: `docs/job-scheduler/` 14개 파일
    
    - 각 문서 하단에 관련 문서 상호 참조 링크 추가

### 기술적 세부사항 (선택사항)

- 총 19개 파일 수정 (+243 lines, -15 lines)
- `x-release-please-version` 플레이스홀더 총 28개 확인

---

## ✅ 체크리스트

- [x]  테스트가 통과했습니다 (`pytest`) - 문서 변경만 있어 테스트 불필요
- [x]  코드 스타일 가이드를 준수했습니다
- [x]  필요한 문서를 업데이트했습니다 (README, API 문서 등)
- [x]  Breaking Change가 없습니다 (있다면 아래에 설명)

---

## ⚠️ Breaking Changes

N/A

---

## 📸 스크린샷 / 로그 (선택사항)

```bash
# 플레이스홀더 적용 확인
$ grep -r "x-release-please-version" docs/ | wc -l
28
```

---

## 📌 추가 메모

- `docs/archive/**` 디렉토리는 frozen 상태이므로 변경하지 않음
- `docs/verification/**` 디렉토리는 특정 버전 테스트 보고서이므로 제외
- PR 대상 브랜치: `develop`