### PR TITLE
tech: remove Phase-prefixed debug logging (#111)

### DIFF
--- a/main.py
+++ b/main.py
@@ -329,8 +329,8 @@ def run_research_stub() -> None:
     with open(output_path, 'w', encoding='utf-8') as f:
         json.dump(stub_card, f, ensure_ascii=False, indent=2)
 
-    logger.info(f"[Phase2C] 연구 카드 스텁 생성 완료: {card_id}")
-    logger.info(f"[Phase2C] 저장 위치: {output_path}")
+    logger.info(f"연구 카드 스텁 생성 완료: {card_id}")
+    logger.info(f"저장 위치: {output_path}")
     logger.warning("[DEPRECATED] research_cards.jsonl is deprecated. Use src.research.executor instead.")
 
 
@@ -365,7 +365,7 @@ def main() -> None:
     # Phase 2C: Story Registry 초기화
     registry = None
     if args.enable_dedup:
-        logger.info("[Phase2C][CONTROL] 중복 제어 모드 활성화")
+        logger.info("중복 제어 모드 활성화")
         registry = init_registry(db_path=args.db_path)
 
         # 과거 스토리 로드
@@ -374,7 +374,7 @@ def main() -> None:
             load_past_stories_into_memory(past_stories)
 
         counts = registry.get_total_count()
-        logger.info(f"[Phase2C][CONTROL] Registry 상태: 수락={counts['accepted']}, 스킵={counts['skipped']}")
+        logger.info(f"Registry 상태: 수락={counts['accepted']}, 스킵={counts['skipped']}")
 
     # 실행 시작
     logger.info("=" * 80)
@@ -509,7 +509,7 @@ def main() -> None:
         # Phase 2C: Registry 정리
         if registry:
             close_registry()
-            logger.info("[Phase2C][CONTROL] Registry 연결 종료")
+            logger.info("Registry 연결 종료")
 
 
 if __name__ == "__main__":

--- a/src/dedup/similarity.py
+++ b/src/dedup/similarity.py
@@ -87,10 +87,10 @@ def observe_similarity(
     global _generation_memory
 
     if not _generation_memory:
-        logger.info("[Phase2B][OBSERVE] 첫 번째 생성 - 비교 대상 없음")
+        logger.info("첫 번째 생성 - 비교 대상 없음")
         return None
 
-    logger.info(f"[Phase2B][OBSERVE] 유사도 관측 시작 (기존 {len(_generation_memory)}개 스토리와 비교)")
+    logger.info(f"유사도 관측 시작 (기존 {len(_generation_memory)}개 스토리와 비교)")
 
     highest_similarity = 0.0
     most_similar_record: Optional[GenerationRecord] = None
@@ -121,15 +121,15 @@ def observe_similarity(
 
     # Log observation (THIS IS THE KEY OUTPUT - observation only)
     if most_similar_record:
-        logger.info(f"[Phase2B][OBSERVE] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-        logger.info(f"[Phase2B][OBSERVE] 유사도 관측 결과:")
-        logger.info(f"[Phase2B][OBSERVE]   현재: \"{current_title}\"")
-        logger.info(f"[Phase2B][OBSERVE]   가장 유사: \"{most_similar_record.title}\" (ID: {most_similar_record.story_id})")
-        logger.info(f"[Phase2B][OBSERVE]   텍스트 유사도: {highest_similarity:.2%}")
-        logger.info(f"[Phase2B][OBSERVE]   정규화 키 일치: {canonical_match_count}/5")
-        logger.info(f"[Phase2B][OBSERVE]   신호 수준: {signal}")
-        logger.info(f"[Phase2B][OBSERVE] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-        logger.info(f"[Phase2B][OBSERVE] ⚠️ 이 관측은 생성에 영향을 주지 않습니다")
+        logger.info(f"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+        logger.info(f"유사도 관측 결과:")
+        logger.info(f"  현재: \"{current_title}\"")
+        logger.info(f"  가장 유사: \"{most_similar_record.title}\" (ID: {most_similar_record.story_id})")
+        logger.info(f"  텍스트 유사도: {highest_similarity:.2%}")
+        logger.info(f"  정규화 키 일치: {canonical_match_count}/5")
+        logger.info(f"  신호 수준: {signal}")
+        logger.info(f"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+        logger.info(f"⚠️ 이 관측은 생성에 영향을 주지 않습니다")
 
         return {
             "closest_story_id": most_similar_record.story_id,
@@ -174,7 +174,7 @@ def add_to_generation_memory(
     )
 
     _generation_memory.append(record)
-    logger.info(f"[Phase2B][OBSERVE] 생성 메모리에 추가: {story_id} (총 {len(_generation_memory)}개)")
+    logger.info(f"생성 메모리에 추가: {story_id} (총 {len(_generation_memory)}개)")
 
 
 # =============================================================================
@@ -210,7 +210,7 @@ def load_past_stories_into_memory(records: List[Any]) -> int:
         _generation_memory.append(gen_record)
         loaded += 1
 
-    logger.info(f"[Phase2C][CONTROL] 과거 스토리 {loaded}개를 in-memory에 로드")
+    logger.info(f"과거 스토리 {loaded}개를 in-memory에 로드")
     return loaded
 
 
@@ -255,4 +255,4 @@ def clear_generation_memory() -> None:
     """Clear the generation memory. Useful for testing."""
     global _generation_memory
     _generation_memory = []
-    logger.info("[Phase2B][OBSERVE] 생성 메모리 초기화 완료")
+    logger.info("생성 메모리 초기화 완료")

--- a/src/registry/story_registry.py
+++ b/src/registry/story_registry.py
@@ -80,8 +80,8 @@ class StoryRegistry:
         self.run_id = run_id or datetime.now().strftime("%Y%m%d_%H%M%S")
         self._conn: Optional[sqlite3.Connection] = None
 
-        logger.info(f"[Phase2C][CONTROL] Story Registry 초기화: {self.db_path}")
-        logger.info(f"[Phase2C][CONTROL] Run ID: {self.run_id}")
+        logger.info(f"Story Registry 초기화: {self.db_path}")
+        logger.info(f"Run ID: {self.run_id}")
 
         self._ensure_directory()
         self._init_db()
@@ -91,7 +91,7 @@ class StoryRegistry:
         db_dir = Path(self.db_path).parent
         if not db_dir.exists():
             db_dir.mkdir(parents=True, exist_ok=True)
-            logger.info(f"[Phase2C][CONTROL] 디렉토리 생성: {db_dir}")
+            logger.info(f"디렉토리 생성: {db_dir}")
 
     def _backup_before_migration(self, from_version: str) -> Optional[str]:
         """
@@ -153,7 +153,7 @@ class StoryRegistry:
                 "INSERT INTO meta (key, value) VALUES ('schema_version', ?)",
                 (SCHEMA_VERSION,)
             )
-            logger.info(f"[Phase2C][CONTROL] 스키마 생성 완료 (v{SCHEMA_VERSION})")
+            logger.info(f"스키마 생성 완료 (v{SCHEMA_VERSION})")
         elif current_version != SCHEMA_VERSION:
             # Backup before migration
             self._backup_before_migration(current_version)
@@ -163,9 +163,9 @@ class StoryRegistry:
                 "UPDATE meta SET value = ? WHERE key = 'schema_version'",
                 (SCHEMA_VERSION,)
             )
-            logger.info(f"[Phase2C][CONTROL] 스키마 마이그레이션 완료: {current_version} -> {SCHEMA_VERSION}")
+            logger.info(f"스키마 마이그레이션 완료: {current_version} -> {SCHEMA_VERSION}")
         else:
-            logger.info(f"[Phase2C][CONTROL] 스키마 버전 확인: v{current_version}")
+            logger.info(f"스키마 버전 확인: v{current_version}")
 
         conn.commit()
 
@@ -230,26 +230,26 @@ class StoryRegistry:
             cursor: Database cursor
             from_version: Version to migrate from
         """
-        logger.info(f"[Phase2C][CONTROL] 스키마 마이그레이션 시작: {from_version} -> {SCHEMA_VERSION}")
+        logger.info(f"스키마 마이그레이션 시작: {from_version} -> {SCHEMA_VERSION}")
 
         if from_version == "1.0.0":
             # Migration from 1.0.0 to 1.1.0
             # Add story-level dedup columns
             try:
                 cursor.execute("ALTER TABLE stories ADD COLUMN story_signature TEXT")
-                logger.info("[Phase2C][CONTROL] Added column: story_signature")
+                logger.info("Added column: story_signature")
             except sqlite3.OperationalError:
                 pass  # Column already exists
 
             try:
                 cursor.execute("ALTER TABLE stories ADD COLUMN canonical_core_json TEXT")
-                logger.info("[Phase2C][CONTROL] Added column: canonical_core_json")
+                logger.info("Added column: canonical_core_json")
             except sqlite3.OperationalError:
                 pass  # Column already exists
 
             try:
                 cursor.execute("ALTER TABLE stories ADD COLUMN research_used_json TEXT")
-                logger.info("[Phase2C][CONTROL] Added column: research_used_json")
+                logger.info("Added column: research_used_json")
             except sqlite3.OperationalError:
                 pass  # Column already exists
 
@@ -258,10 +258,10 @@ class StoryRegistry:
                 CREATE INDEX IF NOT EXISTS idx_stories_signature
                 ON stories(story_signature)
             """)
-            logger.info("[Phase2C][CONTROL] Created index: idx_stories_signature")
+            logger.info("Created index: idx_stories_signature")
 
         else:
-            logger.warning(f"[Phase2C][CONTROL] 알 수 없는 버전에서 마이그레이션: {from_version}")
+            logger.warning(f"알 수 없는 버전에서 마이그레이션: {from_version}")
 
     def add_story(
         self,
@@ -322,7 +322,7 @@ class StoryRegistry:
 
         status = "ACCEPTED" if accepted else "SKIPPED"
         sig_short = story_signature[:16] if story_signature else "none"
-        logger.info(f"[Phase2C][CONTROL] Registry 저장: {story_id} ({status}, sig={sig_short}...)")
+        logger.info(f"Registry 저장: {story_id} ({status}, sig={sig_short}...)")
 
     def add_similarity_edge(
         self,
@@ -400,7 +400,7 @@ class StoryRegistry:
                 source_run_id=row["source_run_id"]
             ))
 
-        logger.info(f"[Phase2C][CONTROL] 과거 스토리 {len(records)}개 로드 완료")
+        logger.info(f"과거 스토리 {len(records)}개 로드 완료")
         return records
 
     def get_total_count(self) -> Dict[str, int]:
@@ -455,7 +455,7 @@ class StoryRegistry:
         if self._conn:
             self._conn.close()
             self._conn = None
-            logger.info("[Phase2C][CONTROL] Registry 연결 종료")
+            logger.info("Registry 연결 종료")
 
 
 # =============================================================================

--- a/src/story/api_client.py
+++ b/src/story/api_client.py
@@ -167,7 +167,7 @@ def generate_semantic_summary(
     Returns:
         str: 1-3 sentence summary
     """
-    logger.info("[Phase2B][OBSERVE] 의미적 요약 생성 시작")
+    logger.info("의미적 요약 생성 시작")
 
     try:
         client = anthropic.Anthropic(api_key=config["api_key"])
@@ -187,10 +187,10 @@ def generate_semantic_summary(
         )
 
         summary = message.content[0].text.strip()
-        logger.info(f"[Phase2B][OBSERVE] 의미적 요약 생성 완료: {summary[:100]}...")
+        logger.info(f"의미적 요약 생성 완료: {summary[:100]}...")
         return summary
 
     except Exception as e:
-        logger.warning(f"[Phase2B][OBSERVE] 요약 생성 실패, 폴백 사용: {e}")
+        logger.warning(f"요약 생성 실패, 폴백 사용: {e}")
         # Fallback: use first 200 chars of story
         return story_text[:200].strip()

--- a/src/story/generator.py
+++ b/src/story/generator.py
@@ -787,16 +787,16 @@ def generate_with_dedup_control(
     Returns:
         Optional[Dict]: 수락된 스토리 결과, SKIP 시 None
     """
-    logger.info("[Phase2C][CONTROL] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-    logger.info("[Phase2C][CONTROL] 중복 제어 생성 시작")
-    logger.info("[Phase2C][CONTROL] 정책: HIGH만 거부, LOW/MEDIUM 수락")
-    logger.info("[Phase2C][CONTROL] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+    logger.info("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+    logger.info("중복 제어 생성 시작")
+    logger.info("정책: HIGH만 거부, LOW/MEDIUM 수락")
+    logger.info("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 
     config = load_environment()
     used_template_ids: set = set()
 
     for attempt in range(max_attempts):
-        logger.info(f"[Phase2C][CONTROL] Attempt {attempt}/{max_attempts - 1}")
+        logger.info(f"Attempt {attempt}/{max_attempts - 1}")
 
         # Template selection (Phase 3B: pass registry for weighted selection)
         if attempt == 0:
@@ -814,7 +814,7 @@ def generate_with_dedup_control(
         if template_id:
             used_template_ids.add(template_id)
 
-        logger.info(f"[Phase2C][CONTROL]   템플릿: {template_id} - {template_name}")
+        logger.info(f"  템플릿: {template_id} - {template_name}")
 
         # Research context selection (unified pipeline)
         research_context = None
@@ -909,12 +909,12 @@ def generate_with_dedup_control(
 
         # Phase 2C: Determine signal and decision
         signal = get_similarity_signal(similarity_observation)
-        logger.info(f"[Phase2C][CONTROL]   신호: {signal}")
+        logger.info(f"  신호: {signal}")
         logger.info(f"[DedupSignal] Signal={signal}, Template={template_id}")
 
         if should_accept_story(signal):
             # ACCEPT
-            logger.info(f"[Phase2C][CONTROL]   결정: ACCEPT")
+            logger.info(f"  결정: ACCEPT")
             logger.info(f"[DedupSignal] Decision=ACCEPT")
 
             # Add to in-memory
@@ -1045,7 +1045,7 @@ def generate_with_dedup_control(
                     None  # template
                 )
                 result["file_path"] = file_path
-                logger.info(f"[Phase2C][CONTROL] 저장 완료: {file_path}")
+                logger.info(f"저장 완료: {file_path}")
 
             # Persist to registry (with story-level dedup fields)
             registry.add_story(
@@ -1070,23 +1070,23 @@ def generate_with_dedup_control(
                     signal=signal
                 )
 
-            logger.info("[Phase2C][CONTROL] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+            logger.info("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
             return result
 
         else:
             # HIGH - need to retry
-            logger.info(f"[Phase2C][CONTROL]   결정: RETRY (HIGH 감지)")
+            logger.info(f"  결정: RETRY (HIGH 감지)")
             logger.info(f"[DedupSignal] Decision=RETRY, Attempt={attempt}")
             if attempt < max_attempts - 1:
-                logger.info(f"[Phase2C][CONTROL]   다음 시도로 진행...")
+                logger.info(f"  다음 시도로 진행...")
             continue
 
     # All attempts exhausted - SKIP
-    logger.info("[Phase2C][CONTROL] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-    logger.info("[Phase2C][CONTROL] 모든 시도 실패 - SKIP")
-    logger.info("[Phase2C][CONTROL] 파일 저장 안함, 루프 계속")
+    logger.info("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+    logger.info("모든 시도 실패 - SKIP")
+    logger.info("파일 저장 안함, 루프 계속")
     logger.info("[DedupSignal] Decision=SKIP, Reason=AllAttemptsExhausted")
-    logger.info("[Phase2C][CONTROL] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+    logger.info("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 
     # Record skip in registry
     registry.add_story(

--- a/src/story/template_loader.py
+++ b/src/story/template_loader.py
@@ -88,7 +88,7 @@ def count_cluster_occurrences_in_registry(
     try:
         recent = registry.load_recent_accepted(limit=lookback)
     except Exception as e:
-        logger.warning(f"[Phase3B][PRE] Registry 조회 실패: {e}")
+        logger.warning(f"Registry 조회 실패: {e}")
         return 0
 
     count = sum(
@@ -175,12 +175,12 @@ def select_random_template(
         filtered = [s for s in candidates if s.get('template_id') not in exclude_template_ids]
         if filtered:  # Only apply if we still have candidates
             candidates = filtered
-            logger.info(f"[Phase2C][CONTROL] 템플릿 강제 제외: {exclude_template_ids}")
+            logger.info(f"템플릿 강제 제외: {exclude_template_ids}")
 
     # Phase 3B-B1: Weighted selection based on registry history
     if registry is not None:
         cluster_count = count_cluster_occurrences_in_registry(registry)
-        logger.info(f"[Phase3B][PRE] Systemic cluster count (last {PHASE3B_LOOKBACK_WINDOW}): {cluster_count}")
+        logger.info(f"Systemic cluster count (last {PHASE3B_LOOKBACK_WINDOW}): {cluster_count}")
 
         if cluster_count >= 4:
             # Compute weights for candidates
@@ -189,7 +189,7 @@ def select_random_template(
             # Log penalty application
             penalty_pct = int((1 - min(weights)) * 100)
             if penalty_pct > 0:
-                logger.info(f"[Phase3B][PRE] Applying weight penalty: -{penalty_pct}%")
+                logger.info(f"Applying weight penalty: -{penalty_pct}%")
 
             # Use weighted random selection
             selected = random.choices(candidates, weights=weights, k=1)[0]
@@ -202,7 +202,7 @@ def select_random_template(
 
     _last_template_id = selected.get('template_id')
 
-    logger.info(f"[Phase3B][PRE] Selected template: {selected.get('template_id')} - {selected.get('template_name')}")
+    logger.info(f"Selected template: {selected.get('template_id')} - {selected.get('template_name')}")
     return selected
 
 


### PR DESCRIPTION
## Summary

- 소스 코드에서 `[Phase2B][OBSERVE]`, `[Phase2C][CONTROL]`, `[Phase3B][PRE]` 접두사 제거
- 개발 단계 디버그 마커로, 프로덕션 코드에서 불필요

## Changes

| 파일 | 변경 |
|------|------|
| `main.py` | 4 |
| `src/registry/story_registry.py` | 15 |
| `src/dedup/similarity.py` | 11 |
| `src/story/api_client.py` | 3 |
| `src/story/generator.py` | 15 |
| `src/story/template_loader.py` | 5 |

## Test plan

- [x] `grep -r "\[Phase" src/` 잔여 확인 (없음)

Fixes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)