### PR TITLE
feat: add custom tags field to story generation API (#109)

### DIFF
--- a/docs/core/API.md
+++ b/docs/core/API.md
@@ -572,6 +572,7 @@ Generate a story directly (blocking).
 ```json
 {
   "topic": "Korean apartment horror",
+  "tags": ["수면공포", "청각공포", "일상공포"],
   "auto_research": true,
   "model": "ollama:qwen3:30b",
   "research_model": null,
@@ -584,6 +585,7 @@ Generate a story directly (blocking).
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `topic` | string | No | null | Story topic. If provided, searches for matching research card |
+| `tags` | string[] | No | null | Custom tags to include. Merged with auto-generated tags (default: `['호러', 'horror']`) (v1.6.0) |
 | `auto_research` | boolean | No | true | Auto-generate research if no matching card found |
 | `model` | string | No | null | Story model. Format: `ollama:qwen3:30b` or Claude model name |
 | `research_model` | string | No | null | Research model for auto-research |

--- a/src/api/routers/story.py
+++ b/src/api/routers/story.py
@@ -75,7 +75,8 @@ async def generate_story(request: StoryGenerateRequest):
             research_model_spec=request.research_model,
             save_output=request.save_output,
             registry=registry,
-            target_length=request.target_length
+            target_length=request.target_length,
+            custom_tags=request.tags,  # v1.6.0: Custom tags support (Issue #109)
         )
 
         if not result.get("success", True):

--- a/src/api/schemas/story.py
+++ b/src/api/schemas/story.py
@@ -16,6 +16,12 @@ class StoryGenerateRequest(BaseModel):
         description="Story topic. If provided, searches for matching research card or auto-generates one.",
         json_schema_extra={"examples": ["Korean apartment horror", "Subway late night encounter"]}
     )
+    # v1.6.0: Custom tags support (Issue #109)
+    tags: Optional[List[str]] = Field(
+        default=None,
+        description="Custom tags to include. Merged with auto-generated tags (default: ['호러', 'horror']).",
+        json_schema_extra={"examples": [["수면공포", "청각공포", "일상공포"]]}
+    )
     auto_research: bool = Field(
         default=True,
         description="Auto-generate research if no matching card found for topic"

--- a/src/story/generator.py
+++ b/src/story/generator.py
@@ -210,7 +210,11 @@ def extract_title_from_story(story_text: str) -> str:
     return "무제"
 
 
-def extract_tags_from_story(story_text: str, template: Dict[str, Any]) -> List[str]:
+def extract_tags_from_story(
+    story_text: str,
+    template: Dict[str, Any],
+    custom_tags: Optional[List[str]] = None
+) -> List[str]:
     """
     소설과 템플릿에서 태그를 추출합니다.
 
@@ -220,6 +224,7 @@ def extract_tags_from_story(story_text: str, template: Dict[str, Any]) -> List[s
     Args:
         story_text (str): 생성된 소설 전체 텍스트
         template (Dict[str, Any]): 프롬프트 템플릿
+        custom_tags (Optional[List[str]]): 사용자 지정 커스텀 태그 (v1.6.0, Issue #109)
 
     Returns:
         List[str]: 추출된 태그 리스트
@@ -230,6 +235,10 @@ def extract_tags_from_story(story_text: str, template: Dict[str, Any]) -> List[s
         ['호러', 'horror', '심리스릴러', 'psychological']
     """
     tags = ["호러", "horror"]
+
+    # v1.6.0: 커스텀 태그 먼저 추가 (우선순위 높음)
+    if custom_tags:
+        tags.extend(custom_tags)
 
     # 템플릿에서 장르 태그 추가
     config = template.get("story_config", {})
@@ -347,7 +356,8 @@ def save_story(
     story_text: str,
     output_dir: str,
     metadata: Optional[Dict[str, Any]] = None,
-    template: Optional[Dict[str, Any]] = None
+    template: Optional[Dict[str, Any]] = None,
+    custom_tags: Optional[List[str]] = None
 ) -> str:
     """
     생성된 소설을 Astro + GraphQL 블로그용 마크다운 파일로 저장합니다.
@@ -360,6 +370,7 @@ def save_story(
         output_dir (str): 출력 디렉토리 경로
         metadata (Optional[Dict[str, Any]]): 저장할 메타데이터
         template (Optional[Dict[str, Any]]): 프롬프트 템플릿 (태그 추출용)
+        custom_tags (Optional[List[str]]): 사용자 지정 커스텀 태그 (v1.6.0, Issue #109)
 
     Returns:
         str: 저장된 마크다운 파일 경로
@@ -381,7 +392,13 @@ def save_story(
 
     # 제목, 태그, 설명 추출
     title = extract_title_from_story(story_text)
-    tags = extract_tags_from_story(story_text, template) if template else ["호러", "horror"]
+    # v1.6.0: custom_tags 지원 (Issue #109)
+    if template:
+        tags = extract_tags_from_story(story_text, template, custom_tags=custom_tags)
+    elif custom_tags:
+        tags = ["호러", "horror"] + custom_tags
+    else:
+        tags = ["호러", "horror"]
     description = generate_description(story_text)
 
     # Escape quotes in description for YAML compatibility
@@ -1109,7 +1126,8 @@ def generate_with_topic(
     research_model_spec: Optional[str] = None,
     save_output: bool = True,
     registry: Any = None,
-    target_length: Optional[int] = None
+    target_length: Optional[int] = None,
+    custom_tags: Optional[List[str]] = None
 ) -> Dict[str, Any]:
     """
     Topic 기반 스토리 생성 (v1.2.0+)
@@ -1129,6 +1147,7 @@ def generate_with_topic(
         save_output: 파일 저장 여부
         registry: StoryRegistry 인스턴스 (중복 체크용)
         target_length: 목표 스토리 길이 (자). None이면 기본값 사용.
+        custom_tags: 사용자 지정 커스텀 태그 (v1.6.0, Issue #109)
 
     Returns:
         Dict with story, metadata, file_path (if saved)
@@ -1310,7 +1329,9 @@ def generate_with_topic(
             "generation": generation_length_meta,
             **research_metadata,
             "story_signature": story_signature,
-            "generation_mode": "topic_based" if topic else "random"
+            "generation_mode": "topic_based" if topic else "random",
+            # v1.6.0: Custom tags support (Issue #109)
+            "custom_tags": custom_tags
         }
     }
 
@@ -1351,7 +1372,8 @@ def generate_with_topic(
             story_text,
             config["output_dir"],
             result["metadata"],
-            None
+            None,
+            custom_tags=custom_tags  # v1.6.0: Custom tags support (Issue #109)
         )
         result["file_path"] = file_path
         logger.info(f"[TopicGen] Saved: {file_path}")

--- a/tests/test_story_tags.py
+++ b/tests/test_story_tags.py
@@ -1,0 +1,188 @@
+"""
+Tests for custom tags feature (Issue #109).
+
+Verifies:
+1. Custom tags are merged with default tags
+2. Duplicate tags are removed
+3. Maximum 10 tags limit is enforced
+4. Tag ordering: default → custom → template → extracted
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from src.story.generator import extract_tags_from_story
+
+
+# =============================================================================
+# Tag Extraction Tests
+# =============================================================================
+
+class TestExtractTagsFromStory:
+    """Tests for extract_tags_from_story function."""
+
+    def test_default_tags_always_included(self):
+        """Default tags ['호러', 'horror'] should always be present."""
+        story_text = "# Test Story\n\nThis is a test story."
+        template = {}
+
+        tags = extract_tags_from_story(story_text, template)
+
+        assert "호러" in tags
+        assert "horror" in tags
+
+    def test_custom_tags_merged(self):
+        """Custom tags should be merged with default tags."""
+        story_text = "# Test Story\n\nThis is a test story."
+        template = {}
+        custom_tags = ["수면공포", "청각공포"]
+
+        tags = extract_tags_from_story(story_text, template, custom_tags=custom_tags)
+
+        assert "호러" in tags
+        assert "horror" in tags
+        assert "수면공포" in tags
+        assert "청각공포" in tags
+
+    def test_custom_tags_no_duplicates(self):
+        """Duplicate tags should be removed."""
+        story_text = "# Test Story\n\nThis is a test story."
+        template = {}
+        custom_tags = ["호러", "custom_tag"]  # "호러" is also a default tag
+
+        tags = extract_tags_from_story(story_text, template, custom_tags=custom_tags)
+
+        # Count occurrences of "호러"
+        horror_count = sum(1 for t in tags if t == "호러")
+        assert horror_count == 1
+        assert "custom_tag" in tags
+
+    def test_max_ten_tags(self):
+        """Tags should be limited to 10."""
+        story_text = "# Test Story\n\nThis is a test story."
+        template = {}
+        # Provide many custom tags to exceed limit
+        custom_tags = [f"tag_{i}" for i in range(15)]
+
+        tags = extract_tags_from_story(story_text, template, custom_tags=custom_tags)
+
+        assert len(tags) <= 10
+
+    def test_template_genre_included(self):
+        """Template genre should be included in tags."""
+        story_text = "# Test Story\n\nThis is a test story."
+        template = {
+            "story_config": {
+                "genre": "서스펜스"
+            }
+        }
+
+        tags = extract_tags_from_story(story_text, template)
+
+        assert "서스펜스" in tags
+
+    def test_template_fear_type_included(self):
+        """Template primary_fear_type should be included (list format)."""
+        story_text = "# Test Story\n\nThis is a test story."
+        template = {
+            "story_elements": {
+                "horror_techniques": {
+                    "primary_fear_type": ["심리공포", "사회공포"]  # Must be a list
+                }
+            }
+        }
+
+        tags = extract_tags_from_story(story_text, template)
+
+        assert "심리공포" in tags
+
+    def test_tags_extracted_from_story_text(self):
+        """Tags in ## 태그 section should be extracted (- format required)."""
+        story_text = """# Test Story
+
+This is a test story.
+
+---
+
+## 태그
+- 일상공포
+- #도시전설
+- 미스터리
+"""
+        template = {}
+
+        tags = extract_tags_from_story(story_text, template)
+
+        assert "일상공포" in tags
+        assert "도시전설" in tags
+        assert "미스터리" in tags
+
+    def test_custom_tags_priority_over_extracted(self):
+        """Custom tags should appear before extracted tags."""
+        story_text = """# Test Story
+
+This is a test story.
+
+---
+
+## 태그
+extracted_tag_1, extracted_tag_2
+"""
+        template = {}
+        custom_tags = ["custom_1", "custom_2"]
+
+        tags = extract_tags_from_story(story_text, template, custom_tags=custom_tags)
+
+        # Custom tags should come before extracted tags
+        custom_1_idx = tags.index("custom_1")
+        custom_2_idx = tags.index("custom_2")
+
+        # Extracted tags may or may not be in the final list (10 tag limit)
+        # But if they are, they should come after custom tags
+        if "extracted_tag_1" in tags:
+            extracted_idx = tags.index("extracted_tag_1")
+            assert custom_1_idx < extracted_idx
+
+    def test_none_custom_tags_handled(self):
+        """None custom_tags should not cause errors."""
+        story_text = "# Test Story\n\nThis is a test story."
+        template = {}
+
+        # Should not raise
+        tags = extract_tags_from_story(story_text, template, custom_tags=None)
+
+        assert "호러" in tags
+        assert "horror" in tags
+
+    def test_empty_custom_tags_handled(self):
+        """Empty custom_tags list should not cause errors."""
+        story_text = "# Test Story\n\nThis is a test story."
+        template = {}
+
+        tags = extract_tags_from_story(story_text, template, custom_tags=[])
+
+        assert "호러" in tags
+        assert "horror" in tags
+
+
+# =============================================================================
+# Integration with generate_with_topic Tests
+# =============================================================================
+
+class TestGenerateWithTopicCustomTags:
+    """Tests for generate_with_topic with custom_tags parameter."""
+
+    def test_custom_tags_in_metadata(self):
+        """custom_tags should be included in result metadata."""
+        # This is a structural test to verify the parameter flows through
+        # Full integration test would require mocking Claude API
+
+        # Verify function signature accepts custom_tags
+        from src.story.generator import generate_with_topic
+        import inspect
+
+        sig = inspect.signature(generate_with_topic)
+        params = sig.parameters
+
+        assert "custom_tags" in params
+        assert params["custom_tags"].default is None


### PR DESCRIPTION
## Summary
- 스토리 생성 API `/story/generate` 엔드포인트에 `tags` 필드 추가
- 사용자 지정 커스텀 태그를 기본 태그 (`["호러", "horror"]`)와 병합
- 태그 우선순위: 기본 → 커스텀 → 템플릿 → 추출 (최대 10개, 중복 제거)

## Changes
- `src/api/schemas/story.py`: `StoryGenerateRequest`에 `tags` 필드 추가
- `src/api/routers/story.py`: `custom_tags` 파라미터 전달
- `src/story/generator.py`: `extract_tags_from_story()`, `save_story()`, `generate_with_topic()` 수정
- `docs/core/API.md`: API 문서 업데이트
- `tests/test_story_tags.py`: 태그 추출 및 병합 테스트 추가 (11개 테스트)

## Test plan
- [x] `pytest tests/test_story_tags.py -v` (11 passed)
- [ ] API 요청 테스트: `curl -X POST localhost:8000/story/generate -d '{"topic":"...", "tags":["수면공포"]}'`

Fixes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)