### PR TITLE
feat: use DISCORD_WEBHOOK_URL env as default webhook_url (#115)

### DIFF
--- a/docs/core/API.md
+++ b/docs/core/API.md
@@ -1435,7 +1435,10 @@ Recommended pattern for n8n or similar workflow tools:
 
 ### Webhook Integration (v1.3.0)
 
-Jobs can be configured to send HTTP POST notifications on completion:
+Jobs can be configured to send HTTP POST notifications on completion.
+
+> **v1.6.1:** `webhook_url`을 생략하면 환경변수 `DISCORD_WEBHOOK_URL`이 자동으로 사용됩니다.
+> 요청에 `webhook_url`을 명시하면 환경변수보다 우선 적용됩니다.
 
 **Configuration (in trigger request):**
 
@@ -1493,6 +1496,9 @@ Note: `cancelled` events do not trigger webhooks by default.
 ### Sync Endpoint Webhooks (v1.4.3)
 
 The sync endpoints (`/research/run`, `/story/generate`) support fire-and-forget webhooks.
+
+> **v1.6.1:** `webhook_url`을 생략하면 환경변수 `DISCORD_WEBHOOK_URL`이 자동으로 사용됩니다.
+> 요청에 `webhook_url`을 명시하면 환경변수보다 우선 적용됩니다.
 
 **Configuration (in request body):**
 

--- a/docs/core/OPERATIONAL_STATUS.md
+++ b/docs/core/OPERATIONAL_STATUS.md
@@ -58,6 +58,7 @@
 
 | 환경 변수 | 기본값 | 설명 |
 |-----------|--------|------|
+| `DISCORD_WEBHOOK_URL` | (없음) | Webhook URL 기본값. 요청에 `webhook_url` 미지정 시 자동 사용 (v1.6.1) |
 | `AUTO_INJECT_RESEARCH` | `true` | 연구 카드 자동 주입 |
 | `RESEARCH_INJECT_TOP_K` | `1` | 주입할 연구 카드 수 |
 | `RESEARCH_INJECT_REQUIRE` | `false` | 연구 카드 필수 여부 |

--- a/src/api/routers/jobs.py
+++ b/src/api/routers/jobs.py
@@ -80,6 +80,7 @@ from src.infra.job_monitor import (
     monitor_all_running_jobs,
     cancel_job as cancel_job_func,
 )
+from src.infra.webhook import resolve_webhook_url
 
 router = APIRouter()
 
@@ -403,10 +404,11 @@ async def trigger_story_generation(request: StoryTriggerRequest):
     update_job_status(job.job_id, "queued")
 
     # v1.3.0: Set webhook configuration
+    webhook_url = resolve_webhook_url(request.webhook_url)
     job_data = load_job(job.job_id)
     if job_data:
-        if request.webhook_url:
-            job_data.webhook_url = request.webhook_url
+        if webhook_url:
+            job_data.webhook_url = webhook_url
             job_data.webhook_events = request.webhook_events
         from src.infra.job_manager import save_job
         save_job(job_data)
@@ -473,10 +475,11 @@ async def trigger_research_generation(request: ResearchTriggerRequest):
     update_job_status(job.job_id, "queued")
 
     # v1.3.0: Set webhook configuration
+    webhook_url = resolve_webhook_url(request.webhook_url)
     job_data = load_job(job.job_id)
     if job_data:
-        if request.webhook_url:
-            job_data.webhook_url = request.webhook_url
+        if webhook_url:
+            job_data.webhook_url = webhook_url
             job_data.webhook_events = request.webhook_events
         from src.infra.job_manager import save_job
         save_job(job_data)
@@ -604,7 +607,7 @@ async def trigger_batch_jobs(request: BatchTriggerRequest):
     # Create batch record
     batch = create_batch(
         job_ids=job_ids,
-        webhook_url=request.webhook_url,
+        webhook_url=resolve_webhook_url(request.webhook_url),
         webhook_events=request.webhook_events,
     )
 

--- a/src/api/routers/research.py
+++ b/src/api/routers/research.py
@@ -30,7 +30,7 @@ from ..schemas.research import (
     MatchingTemplateItem,
 )
 from ..services import research_service
-from src.infra.webhook import fire_and_forget_webhook
+from src.infra.webhook import fire_and_forget_webhook, resolve_webhook_url
 
 router = APIRouter()
 
@@ -54,13 +54,16 @@ async def run_research(request: ResearchRunRequest):
         timeout=request.timeout,
     )
 
+    # Resolve webhook URL: request value > DISCORD_WEBHOOK_URL env > None
+    webhook_url = resolve_webhook_url(request.webhook_url)
+
     # Propagate errors as HTTP errors (Issue #2)
     status = result.get("status", "error")
     if status == "error":
         # v1.4.3: Fire webhook for error case before raising
-        if request.webhook_url:
+        if webhook_url:
             fire_and_forget_webhook(
-                url=request.webhook_url,
+                url=webhook_url,
                 endpoint="/research/run",
                 status="error",
                 result={"error": result.get("message") or "Research generation failed"},
@@ -71,9 +74,9 @@ async def run_research(request: ResearchRunRequest):
         )
     elif status == "timeout":
         # v1.4.3: Fire webhook for timeout case before raising
-        if request.webhook_url:
+        if webhook_url:
             fire_and_forget_webhook(
-                url=request.webhook_url,
+                url=webhook_url,
                 endpoint="/research/run",
                 status="error",
                 result={"error": result.get("message") or "Research generation timed out"},
@@ -85,9 +88,9 @@ async def run_research(request: ResearchRunRequest):
 
     # v1.4.3: Fire webhook for success case
     webhook_triggered = False
-    if request.webhook_url:
+    if webhook_url:
         webhook_triggered = fire_and_forget_webhook(
-            url=request.webhook_url,
+            url=webhook_url,
             endpoint="/research/run",
             status="success",
             result={

--- a/src/api/routers/story.py
+++ b/src/api/routers/story.py
@@ -23,7 +23,7 @@ from ..schemas.story import (
     StoryListResponse,
     StoryDetailResponse,
 )
-from src.infra.webhook import fire_and_forget_webhook
+from src.infra.webhook import fire_and_forget_webhook, resolve_webhook_url
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +56,9 @@ async def generate_story(request: StoryGenerateRequest):
     - Selects a random template
     - Uses existing research cards based on template affinity
     """
+    # Resolve webhook URL: request value > DISCORD_WEBHOOK_URL env > None
+    webhook_url = resolve_webhook_url(request.webhook_url)
+
     try:
         from src.story.generator import generate_with_topic
         from src.registry.story_registry import StoryRegistry
@@ -82,9 +85,9 @@ async def generate_story(request: StoryGenerateRequest):
         if not result.get("success", True):
             # v1.4.3: Fire webhook for failure case
             webhook_triggered = False
-            if request.webhook_url:
+            if webhook_url:
                 webhook_triggered = fire_and_forget_webhook(
-                    url=request.webhook_url,
+                    url=webhook_url,
                     endpoint="/story/generate",
                     status="error",
                     result={"error": result.get("error", "Generation failed")},
@@ -113,9 +116,9 @@ async def generate_story(request: StoryGenerateRequest):
 
         # v1.4.3: Fire webhook for success case
         webhook_triggered = False
-        if request.webhook_url:
+        if webhook_url:
             webhook_triggered = fire_and_forget_webhook(
-                url=request.webhook_url,
+                url=webhook_url,
                 endpoint="/story/generate",
                 status="success",
                 result={
@@ -145,9 +148,9 @@ async def generate_story(request: StoryGenerateRequest):
         logger.error(f"[StoryAPI] Generation error: {e}", exc_info=True)
         # v1.4.3: Fire webhook for exception case
         webhook_triggered = False
-        if request.webhook_url:
+        if webhook_url:
             webhook_triggered = fire_and_forget_webhook(
-                url=request.webhook_url,
+                url=webhook_url,
                 endpoint="/story/generate",
                 status="error",
                 result={"error": str(e)},

--- a/src/infra/webhook.py
+++ b/src/infra/webhook.py
@@ -7,6 +7,7 @@ v1.4.3: Fire-and-forget webhook support for sync endpoints.
 
 import asyncio
 import logging
+import os
 import threading
 from datetime import datetime
 from typing import Any, Dict, Optional
@@ -15,6 +16,14 @@ import httpx
 from src.infra.job_manager import Job, WebhookEvent, save_job
 
 logger = logging.getLogger(__name__)
+
+
+def resolve_webhook_url(request_url: Optional[str] = None) -> Optional[str]:
+    """Resolve webhook URL: request value > DISCORD_WEBHOOK_URL env > None."""
+    if request_url:
+        return request_url
+    return os.getenv("DISCORD_WEBHOOK_URL")
+
 
 # Webhook configuration
 WEBHOOK_TIMEOUT_SECONDS = 30


### PR DESCRIPTION
## Summary

- `webhook_url`을 요청에서 생략하면 환경변수 `DISCORD_WEBHOOK_URL`을 자동으로 사용하도록 개선
- `resolve_webhook_url()` 헬퍼 함수를 `src/infra/webhook.py`에 추가
- 모든 sync/legacy trigger 엔드포인트에 적용

Fixes #115

## Changes

| 파일 | 변경 |
|------|------|
| `src/infra/webhook.py` | `resolve_webhook_url()` 헬퍼 함수 추가 |
| `src/api/routers/story.py` | `/story/generate` 핸들러에서 webhook_url resolve |
| `src/api/routers/research.py` | `/research/run` 핸들러에서 webhook_url resolve |
| `src/api/routers/jobs.py` | legacy trigger 2개 + batch trigger에서 webhook_url resolve |
| `docs/core/API.md` | Webhook Integration 섹션에 DISCORD_WEBHOOK_URL 기본값 동작 설명 |
| `docs/core/OPERATIONAL_STATUS.md` | 환경변수 테이블에 DISCORD_WEBHOOK_URL 추가 |

## Resolution Logic

```
request.webhook_url → 있으면 그대로 사용 (기존 동작)
                    → 없으면 os.getenv("DISCORD_WEBHOOK_URL") 사용
                    → 환경변수도 없으면 None (웹훅 미발송)
```

## Not Changed

- Pydantic 스키마 변경 없음
- Scheduler 기반 `POST /jobs` (type: story/research)는 변경 없음 (별도 구조)
- webhook 전송 로직 자체 변경 없음

## Test plan

- [x] `pytest` 전체 실행: 962 passed, 61 skipped (기존 실패 1개는 환경 의존 테스트로 이번 변경 무관)
- [x] `resolve_webhook_url` 사용 위치 검증 완료 (9곳)
- [x] `request.webhook_url` 직접 사용 잔존 확인 → 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)