### PR TITLE
feat: add topic/tags/research params to story job execution (#123)

### DIFF
--- a/docs/core/API.md
+++ b/docs/core/API.md
@@ -254,6 +254,22 @@ curl -X POST http://localhost:8000/story/generate \
 }
 ```
 
+**Topic-based story example (v1.6.1):**
+
+```json
+{
+  "type": "story",
+  "params": {
+    "topic": "한국 아파트 호러",
+    "tags": ["수면공포", "청각공포"],
+    "auto_research": true,
+    "research_model": "deep-research",
+    "thumbnail_provider": "local_sd"
+  },
+  "priority": 10
+}
+```
+
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `type` | string | **Yes** | - | Job 타입: `"story"` 또는 `"research"` |
@@ -264,15 +280,16 @@ curl -X POST http://localhost:8000/story/generate \
 
 | Field | Type | Description |
 |-------|------|-------------|
+| `topic` | string | 스토리 주제. 지정 시 topic 기반 생성 사용 (v1.6.1) |
+| `tags` | string[] | 커스텀 태그 (v1.6.1) |
+| `auto_research` | boolean | 연구 카드 자동 생성 (기본: true) (v1.6.1) |
+| `research_model` | string | 연구 생성 모델 선택 (v1.6.1) |
+| `thumbnail_provider` | string | 썸네일 프로바이더: `openai_dalle3`, `stability_ai`, `flux`, `local_sd` (v1.6.1) |
 | `max_stories` | integer | 생성할 최대 스토리 수 (1-100, 기본 1) |
 | `duration_seconds` | integer | 실행 제한 시간 (초) |
 | `enable_dedup` | boolean | 중복 검사 활성화 (기본 false) |
 | `model` | string | 모델 선택 |
 | `target_length` | integer | 목표 스토리 길이 (300-10000자) |
-
-> **⚠️ 제한사항:** Story Job은 현재 `topic`, `tags`, `webhook_url` 파라미터를 지원하지 않습니다.
-> topic/tags를 지정하여 스토리를 생성하려면 `POST /story/generate`를 사용하세요.
-> 이 제한은 [#123](https://github.com/VinylStage/horror-story-generator/issues/123)에서 추적 중입니다.
 
 **Research Job params:**
 
@@ -533,14 +550,14 @@ Job의 실행 이력 (JobRun)을 조회합니다.
 | 용도 | 권장 API | 특징 |
 |------|---------|------|
 | **topic/tags 지정 스토리 생성** | `POST /story/generate` | Blocking. topic, tags, webhook_url 모두 지원 |
-| **대량/주기적 스토리 생성** | `POST /jobs` + Scheduler | Async, 큐 기반. 단, topic/tags 미지원 ([#123](https://github.com/VinylStage/horror-story-generator/issues/123)) |
+| **대량/주기적 스토리 생성** | `POST /jobs` + Scheduler | Async, 큐 기반. topic/tags 지원 (v1.6.1) |
 | **topic 지정 연구 생성 (blocking)** | `POST /research/run` | Blocking. Ollama/Gemini 직접 실행 |
 | **연구 생성 (async)** | `POST /jobs` (type: research) | Scheduler 큐 기반 비동기 실행 |
 | **하위 호환 (legacy)** | `POST /jobs/story/trigger` | ⚠️ Deprecated. 신규 클라이언트 비권장 |
 
 **요약:**
-- **topic/tags가 필요하면** → `POST /story/generate` (blocking)
-- **스케줄러 큐가 필요하면** → `POST /jobs` + Scheduler API (topic/tags 미지원)
+- **topic/tags가 필요하면** → `POST /story/generate` (blocking) 또는 `POST /jobs` (async, v1.6.1)
+- **스케줄러 큐가 필요하면** → `POST /jobs` + Scheduler API
 - **Legacy trigger** → 하위 호환용으로만 유지, 신규 사용 비권장
 
 ---

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ from typing import Dict, Any, Optional
 from dotenv import load_dotenv
 from src.story.generator import (
     generate_horror_story, customize_template,
-    generate_with_dedup_control
+    generate_with_dedup_control, generate_with_topic
 )
 from src.infra.logging_config import setup_logging
 from src.dedup.similarity import load_past_stories_into_memory
@@ -279,6 +279,37 @@ def parse_args():
         default=None,
         help="목표 스토리 길이(자). 300-10000 범위. 미지정시 기본값 (~3000-4000자) 사용"
     )
+    # Topic-based generation (Issue #123)
+    parser.add_argument(
+        "--topic",
+        type=str,
+        default=None,
+        help="스토리 주제. 지정 시 topic 기반 생성 (generate_with_topic 사용)"
+    )
+    parser.add_argument(
+        "--tags",
+        nargs='*',
+        default=None,
+        help="커스텀 태그. 예: --tags 수면공포 청각공포"
+    )
+    parser.add_argument(
+        "--auto-research",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="연구 카드 자동 생성 (기본: True). --no-auto-research로 비활성화"
+    )
+    parser.add_argument(
+        "--research-model",
+        type=str,
+        default=None,
+        help="연구 생성 모델 선택"
+    )
+    parser.add_argument(
+        "--thumbnail-provider",
+        type=str,
+        default=None,
+        help="썸네일 생성 프로바이더. openai_dalle3, stability_ai, flux, local_sd"
+    )
     return parser.parse_args()
 
 
@@ -353,6 +384,10 @@ def main() -> None:
     # CLI 인자 파싱
     args = parse_args()
 
+    # Issue #123: Set thumbnail provider env if specified
+    if args.thumbnail_provider:
+        os.environ["THUMBNAIL_PROVIDER"] = args.thumbnail_provider
+
     # Phase 2C: 연구 스텁 명령 처리
     if args.run_research_stub:
         run_research_stub()
@@ -387,6 +422,14 @@ def main() -> None:
     logger.info(f"  - 중복 제어: {'활성화 (HIGH만 거부)' if args.enable_dedup else '비활성화'}")
     logger.info(f"  - 모델: {args.model or '기본 Claude Sonnet'}")
     logger.info(f"  - 목표 길이: {args.target_length or '기본값 (~3000-4000자)'}자")
+    if args.topic:
+        logger.info(f"  - 주제: {args.topic}")
+    if args.tags:
+        logger.info(f"  - 태그: {args.tags}")
+    if args.research_model:
+        logger.info(f"  - 연구 모델: {args.research_model}")
+    if args.thumbnail_provider:
+        logger.info(f"  - 썸네일 프로바이더: {args.thumbnail_provider}")
     logger.info("=" * 80)
 
     # 통계 추적
@@ -422,8 +465,20 @@ def main() -> None:
             logger.info(f"[{stories_generated + 1}] 소설 생성 시작")
             logger.info("=" * 80)
 
+            # Issue #123: Topic-based generation takes priority
+            if args.topic is not None:
+                result = generate_with_topic(
+                    topic=args.topic,
+                    auto_research=args.auto_research,
+                    model_spec=args.model,
+                    research_model_spec=args.research_model,
+                    save_output=True,
+                    registry=registry,
+                    target_length=args.target_length,
+                    custom_tags=args.tags,
+                )
             # Phase 2C: 중복 제어 모드에 따른 생성
-            if args.enable_dedup and registry:
+            elif args.enable_dedup and registry:
                 result = generate_with_dedup_control(registry=registry, model_spec=args.model, target_length=args.target_length)
                 if result is None:
                     # SKIP - story was too similar after all attempts

--- a/src/api/routers/jobs.py
+++ b/src/api/routers/jobs.py
@@ -124,6 +124,19 @@ def build_story_command(params: dict) -> list[str]:
     if params.get("target_length"):
         cmd.extend(["--target-length", str(params["target_length"])])
 
+    # Issue #123: Topic-based generation params
+    if params.get("topic"):
+        cmd.extend(["--topic", params["topic"]])
+    if params.get("tags"):
+        cmd.append("--tags")
+        cmd.extend(params["tags"])
+    if params.get("auto_research") is False:
+        cmd.append("--no-auto-research")
+    if params.get("research_model"):
+        cmd.extend(["--research-model", params["research_model"]])
+    if params.get("thumbnail_provider"):
+        cmd.extend(["--thumbnail-provider", params["thumbnail_provider"]])
+
     return cmd
 
 

--- a/src/scheduler/executor.py
+++ b/src/scheduler/executor.py
@@ -201,6 +201,19 @@ class SubprocessJobHandler(JobHandler):
             if params.get("target_length"):
                 cmd.extend(["--target-length", str(params["target_length"])])
 
+            # Issue #123: Topic-based generation params
+            if params.get("topic"):
+                cmd.extend(["--topic", params["topic"]])
+            if params.get("tags"):
+                cmd.append("--tags")
+                cmd.extend(params["tags"])
+            if params.get("auto_research") is False:
+                cmd.append("--no-auto-research")
+            if params.get("research_model"):
+                cmd.extend(["--research-model", params["research_model"]])
+            if params.get("thumbnail_provider"):
+                cmd.extend(["--thumbnail-provider", params["thumbnail_provider"]])
+
             return cmd
 
         elif job.job_type == "research":


### PR DESCRIPTION
## Summary

- `POST /jobs` (type=story) 스케줄러 기반 스토리 생성에서 topic, tags, auto_research, research_model, thumbnail_provider 파라미터 지원 추가
- `main.py` CLI에 5개 인자 추가 및 `generate_with_topic()` 연결
- 스케줄러 executor + legacy command builder 동시 업데이트

Fixes #123

## Changes

| 파일 | 변경 |
|------|------|
| `main.py` | `--topic`, `--tags`, `--auto-research`, `--research-model`, `--thumbnail-provider` CLI 인자 추가 + 생성 로직 연결 |
| `src/scheduler/executor.py` | `_build_command()` story 분기에 새 params 매핑 |
| `src/api/routers/jobs.py` | `build_story_command()` 동일 매핑 (legacy) |
| `docs/core/API.md` | POST /jobs Story Job params 테이블 업데이트 + topic 기반 예시 추가 |

## New Story Job Params

| Param | Type | Description |
|-------|------|-------------|
| `topic` | string | 스토리 주제 (topic 기반 생성) |
| `tags` | string[] | 커스텀 태그 |
| `auto_research` | boolean | 연구 카드 자동 생성 (기본: true) |
| `research_model` | string | 연구 생성 모델 |
| `thumbnail_provider` | string | 썸네일 프로바이더 |

## Example

```json
{
  "type": "story",
  "params": {
    "topic": "한국 아파트 호러",
    "tags": ["수면공포", "청각공포"],
    "auto_research": true,
    "research_model": "deep-research",
    "thumbnail_provider": "local_sd"
  },
  "priority": 10
}
```

## Not Changed

- Pydantic 스키마 변경 없음 (params는 이미 dict 타입)
- `generate_with_topic()` 함수 자체 변경 없음
- 스케줄러 webhook 구조 변경 없음

## Test plan

- [x] pytest: 962 passed, 61 skipped, 0 failed
- [x] CLI 인자 파싱 검증
- [x] command builder 매핑 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)