### PR TITLE
fix: update task status to COMPLETED/FAILED after execution (#129)

### DIFF
--- a/docs/job-scheduler/API_CONTRACT.md
+++ b/docs/job-scheduler/API_CONTRACT.md
@@ -41,6 +41,8 @@ Used for:
 |------|--------|
 | QUEUED | Waiting in queue |
 | RUNNING | Currently executing |
+| COMPLETED | Execution finished successfully |
+| FAILED | Execution failed |
 | CANCELLED | Cancelled before completion |
 
 > These statuses are exposed via API and webhooks.

--- a/src/scheduler/dispatcher.py
+++ b/src/scheduler/dispatcher.py
@@ -39,6 +39,17 @@ from .queue_manager import QueueManager
 logger = logging.getLogger(__name__)
 
 
+def _run_status_to_task_status(run_status: TaskRunStatus) -> TaskStatus:
+    """Map TaskRun terminal status to Task terminal status."""
+    if run_status == TaskRunStatus.COMPLETED:
+        return TaskStatus.COMPLETED
+    elif run_status == TaskRunStatus.FAILED:
+        return TaskStatus.FAILED
+    else:
+        # SKIPPED → treat as CANCELLED at task level
+        return TaskStatus.CANCELLED
+
+
 class DispatcherState(str, Enum):
     """Dispatcher lifecycle states."""
 
@@ -222,9 +233,11 @@ class Dispatcher:
             # Execute via executor
             completed_run = self._executor.execute(task, task_run)
 
-            # Update task finished_at
+            # Update task status and finished_at
+            task_status = _run_status_to_task_status(completed_run.status)
             self.persistence.update_task(
                 task.task_id,
+                status=task_status,
                 finished_at=completed_run.finished_at,
             )
 
@@ -303,9 +316,11 @@ class Dispatcher:
             try:
                 completed_run = self._executor.execute(claimed_task, task_run)
 
-                # Update task finished_at
+                # Update task status and finished_at
+                task_status = _run_status_to_task_status(completed_run.status)
                 self.persistence.update_task(
                     claimed_task.task_id,
+                    status=task_status,
                     finished_at=completed_run.finished_at,
                 )
 
@@ -525,9 +540,11 @@ class Dispatcher:
             try:
                 completed_run = self._executor.execute(task, task_run)
 
-                # Update task finished_at
+                # Update task status and finished_at
+                task_status = _run_status_to_task_status(completed_run.status)
                 self.persistence.update_task(
                     task.task_id,
+                    status=task_status,
                     finished_at=completed_run.finished_at,
                 )
 

--- a/src/scheduler/entities.py
+++ b/src/scheduler/entities.py
@@ -26,11 +26,15 @@ class TaskStatus(str, Enum):
     From API_CONTRACT.md Section 2.1:
     - QUEUED: Waiting in queue
     - RUNNING: Currently executing
+    - COMPLETED: Execution finished successfully
+    - FAILED: Execution failed
     - CANCELLED: Cancelled before completion
     """
 
     QUEUED = "QUEUED"
     RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
     CANCELLED = "CANCELLED"
 
 

--- a/src/scheduler/recovery.py
+++ b/src/scheduler/recovery.py
@@ -165,8 +165,10 @@ class RecoveryManager:
                     error="Scheduler crash recovery",
                 )
 
-                # Update task finished_at
-                self.persistence.update_task(task.task_id, finished_at=now)
+                # Update task status and finished_at
+                self.persistence.update_task(
+                    task.task_id, status=TaskStatus.FAILED, finished_at=now,
+                )
 
             elif task_run.status is None or not task_run.is_terminal():
                 # Crash during execution
@@ -181,17 +183,23 @@ class RecoveryManager:
                     error="Scheduler crash recovery",
                 )
 
-                # Update task finished_at
-                self.persistence.update_task(task.task_id, finished_at=now)
-
-            else:
-                # Crash after completion - just update task finished_at
-                logger.info(
-                    f"Task {task.task_id}: TaskRun terminal, updating finished_at only"
+                # Update task status and finished_at
+                self.persistence.update_task(
+                    task.task_id, status=TaskStatus.FAILED, finished_at=now,
                 )
 
+            else:
+                # Crash after completion - update task status and finished_at
+                logger.info(
+                    f"Task {task.task_id}: TaskRun terminal ({task_run.status.value}), "
+                    f"syncing task status"
+                )
+
+                from .dispatcher import _run_status_to_task_status
+                task_status = _run_status_to_task_status(task_run.status)
                 self.persistence.update_task(
                     task.task_id,
+                    status=task_status,
                     finished_at=task_run.finished_at or now,
                 )
 

--- a/tests/scheduler/test_execution_paths.py
+++ b/tests/scheduler/test_execution_paths.py
@@ -84,7 +84,7 @@ class TestEPNormalExecution:
 
         # Verify task state
         task_fresh = persistence.get_task(task.task_id)
-        assert task_fresh.status == TaskStatus.RUNNING
+        assert task_fresh.status == TaskStatus.COMPLETED
         assert task_fresh.finished_at is not None
 
     def test_ep_norm_02_execution_order_matches_queue_order(

--- a/tests/scheduler/test_state_transitions.py
+++ b/tests/scheduler/test_state_transitions.py
@@ -333,10 +333,13 @@ class TestSTExternalStates:
         """
         ST-EXT-01: API returns only external Task statuses.
 
-        Assertion: Status in {QUEUED, RUNNING, CANCELLED}
+        Assertion: Status in {QUEUED, RUNNING, COMPLETED, FAILED, CANCELLED}
         """
         # Verify all TaskStatus values are external
-        valid_statuses = {TaskStatus.QUEUED, TaskStatus.RUNNING, TaskStatus.CANCELLED}
+        valid_statuses = {
+            TaskStatus.QUEUED, TaskStatus.RUNNING,
+            TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.CANCELLED,
+        }
 
         # All status values should be in the valid set
         for status in TaskStatus:

--- a/tests/scheduler/test_webhooks.py
+++ b/tests/scheduler/test_webhooks.py
@@ -41,10 +41,10 @@ class TestWHSchema:
         WH-SCHEMA-01: Task status in webhook matches API.
 
         Assertions:
-        - Webhook status ∈ {QUEUED, RUNNING, CANCELLED}
+        - Webhook status ∈ {QUEUED, RUNNING, COMPLETED, FAILED, CANCELLED}
         """
         # These are the only valid Task statuses per API_CONTRACT.md
-        valid_task_statuses = {"QUEUED", "RUNNING", "CANCELLED"}
+        valid_task_statuses = {"QUEUED", "RUNNING", "COMPLETED", "FAILED", "CANCELLED"}
 
         # Verify TaskStatus enum values
         actual_statuses = {status.value for status in TaskStatus}


### PR DESCRIPTION
## Summary

- **TaskStatus enum 확장**: COMPLETED, FAILED 상태 추가 (기존: QUEUED, RUNNING, CANCELLED)
- **Dispatcher 수정**: 실행 완료 후 TaskRun status → Task status 매핑 추가 (3곳: dispatch_one, concurrent group, direct execution)
- **Recovery 수정**: crash recovery 시에도 동일하게 Task status 업데이트 (3곳)
- **테스트/문서 업데이트**: TaskStatus 검증 테스트 및 API_CONTRACT.md 반영

## Root Cause

`dispatcher.py`에서 `update_task()` 호출 시 `finished_at`만 전달하고 `status=`를 누락. `TaskStatus`에 COMPLETED/FAILED가 없어서 완료 상태를 표현할 수 없었음.

## Test plan

- [x] `pytest tests/scheduler/` — 117 passed, 8 skipped
- [x] `pytest tests/test_tasks_router.py` — 9 passed

Fixes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)