### PR TITLE
fix: send Discord webhook on scheduler task completion (#132)

### DIFF
--- a/src/scheduler/service.py
+++ b/src/scheduler/service.py
@@ -28,6 +28,7 @@ from .entities import (
     TaskTemplate,
 )
 from .persistence import PersistenceAdapter
+from src.infra.webhook import fire_and_forget_webhook, resolve_webhook_url
 from .queue_manager import QueueManager
 from .dispatcher import Dispatcher
 from .executor import Executor, SubprocessTaskHandler
@@ -137,6 +138,25 @@ class SchedulerService:
             # Handle TaskGroup completion (DEC-012)
             # This checks for stop-on-failure and updates group status
             queue_manager.handle_group_job_completion(task, task_run)
+
+            # Send webhook notification if configured
+            webhook_url = resolve_webhook_url()
+            if webhook_url and task_run.is_terminal():
+                status = "success" if task_run.status == TaskRunStatus.COMPLETED else "error"
+                fire_and_forget_webhook(
+                    url=webhook_url,
+                    endpoint=f"/tasks/{task.task_id}",
+                    status=status,
+                    result={
+                        "task_id": task.task_id,
+                        "task_type": task.task_type,
+                        "run_id": task_run.run_id,
+                        "status": task_run.status.value,
+                        "exit_code": task_run.exit_code,
+                        "error": task_run.error,
+                        "artifacts": task_run.artifacts,
+                    },
+                )
 
         dispatcher.set_on_job_completed(on_task_completed)
 


### PR DESCRIPTION
## Summary

- `on_task_completed` 콜백에 `fire_and_forget_webhook()` 호출 추가
- 스케줄러 태스크 완료/실패/스킵 시 Discord 웹훅 알림 발송
- `DISCORD_WEBHOOK_URL` 환경변수가 설정된 경우에만 동작

## Root Cause

직접 API (`/story/generate`, `/research/run`)에서는 웹훅이 발송되지만, 스케줄러 경로(`POST /tasks` → dispatcher)에서는 `on_task_completed` 콜백에 웹훅 호출이 없었음.

## Test plan

- [x] `pytest tests/scheduler/` — 117 passed, 8 skipped
- [x] `pytest tests/test_tasks_router.py` — 9 passed
- [x] 라이브 테스트: research 태스크 등록 → COMPLETED → 웹훅 발송 확인

Fixes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)