### PR TITLE
fix: replace hardcoded webhook version with __version__ (#141)

### DIFF
--- a/src/infra/webhook.py
+++ b/src/infra/webhook.py
@@ -12,6 +12,8 @@ from datetime import datetime
 from typing import Any, Dict, Optional
 import httpx
 
+from src import __version__
+
 logger = logging.getLogger(__name__)
 
 
@@ -119,7 +121,7 @@ def build_discord_embed_payload(
         "color": color,
         "fields": fields,
         "timestamp": datetime.now().isoformat(),
-        "footer": {"text": "Horror Story Generator v1.4"},
+        "footer": {"text": f"Horror Story Generator v{__version__}"},
     }
 
     return {
@@ -148,8 +150,6 @@ def build_task_discord_embed_payload(
     Returns:
         Discord-compatible payload with embeds
     """
-    from src import __version__
-
     is_success = status == "success"
     color = DISCORD_COLOR_SUCCESS if is_success else DISCORD_COLOR_ERROR
     emoji = "📋" if is_success else "📋❌"
@@ -242,7 +242,7 @@ def _send_webhook_in_thread(
                 # Build headers based on webhook type
                 headers = {
                     "Content-Type": "application/json",
-                    "User-Agent": "HorrorStoryGenerator/1.4",
+                    "User-Agent": f"HorrorStoryGenerator/{__version__}",
                 }
                 # Add custom headers only for non-Discord webhooks
                 if not is_discord:


### PR DESCRIPTION
## Summary

- Replace hardcoded `"v1.4"` in Discord embed footer with dynamic `__version__` from `src/__init__.py`
- Replace hardcoded `"HorrorStoryGenerator/1.4"` User-Agent header with dynamic version
- Remove redundant local `from src import __version__` in `build_task_discord_embed_payload()` (now imported at module level)

## Root Cause

`build_discord_embed_payload()` and `_send_webhook_in_thread()` had version hardcoded as `"1.4"` since their initial implementation, while `build_task_discord_embed_payload()` (added later) already used the dynamic import correctly.

## Test plan

- [x] All 37 webhook tests pass (`tests/test_sync_webhook.py`)
- [x] Footer assertion uses pattern match (`"Horror Story Generator" in text`), not exact version — no test changes needed

Fixes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)