### PR TITLE
fix: handle Claude API refusal response in call_claude_api (#153)

### DIFF
--- a/src/story/api_client.py
+++ b/src/story/api_client.py
@@ -67,6 +67,9 @@ def call_claude_api(
             ]
         )
 
+        if not message.content:
+            stop_reason = getattr(message, 'stop_reason', 'unknown')
+            raise Exception(f"Claude API refused to generate content (stop_reason: {stop_reason})")
         story_text = message.content[0].text
 
         # Phase 1: Defensive usage extraction - handle missing usage gracefully


### PR DESCRIPTION
## Summary

Claude API가 `stop_reason: "refusal"`을 반환할 때 `message.content`가 빈 배열로 오는 경우를 처리합니다.

## 변경 내용

**`src/story/api_client.py`**

```python
# 수정 전 — content 빈 배열이면 IndexError
story_text = message.content[0].text

# 수정 후 — 명확한 에러 메시지
if not message.content:
    stop_reason = getattr(message, 'stop_reason', 'unknown')
    raise Exception(f"Claude API refused to generate content (stop_reason: {stop_reason})")
story_text = message.content[0].text
```

발생한 exception은 기존 `except Exception as e:` 블록의 `logger.error()`가 처리합니다.

## 영향

- 기존: `"Claude API 호출 중 오류 발생: list index out of range"` — 원인 불명
- 수정 후: `"Claude API refused to generate content (stop_reason: refusal)"` — 명확한 원인 표시
- 스케줄러 TaskRun `error` 필드에 실제 거부 사유가 기록됨

## 테스트

- E2E: 콘텐츠 정책 트리거 주제로 스케줄러 태스크 등록 시 `FAILED` + 명확한 에러 메시지 확인

Fixes #153